### PR TITLE
Added util.Stat that returns os.FileInfo

### DIFF
--- a/helper/chroot/chroot.go
+++ b/helper/chroot/chroot.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/helper/polyfill"
+	"github.com/go-git/go-billy/v5/util"
 )
 
 // ChrootHelper is a helper to implement billy.Chroot.
@@ -222,6 +223,15 @@ func (fs *ChrootHelper) Capabilities() billy.Capability {
 	return billy.Capabilities(fs.underlying)
 }
 
+type fileInfo struct {
+	os.FileInfo
+	name string
+}
+
+func (fi *fileInfo) Name() string {
+	return fi.name
+}
+
 type file struct {
 	billy.File
 	name string
@@ -239,4 +249,13 @@ func newFile(fs billy.Filesystem, f billy.File, filename string) billy.File {
 
 func (f *file) Name() string {
 	return f.name
+}
+
+func (f *file) Stat() (os.FileInfo, error) {
+	fi, err := util.Stat(f.File)
+	if err != nil {
+		return fi, err
+	}
+	name := f.Name()
+	return &fileInfo{fi, name}, nil
 }

--- a/util/util.go
+++ b/util/util.go
@@ -207,6 +207,15 @@ func TempDir(fs billy.Dir, dir, prefix string) (name string, err error) {
 	return
 }
 
+// Stat returns the os.FileInfo structure describing file.
+func Stat(f billy.File) (os.FileInfo, error) {
+	fi, ok := f.(interface{ Stat() (os.FileInfo, error) })
+	if !ok {
+		return nil, billy.ErrNotSupported
+	}
+	return fi.Stat()
+}
+
 type underlying interface {
 	Underlying() billy.Basic
 }


### PR DESCRIPTION
This PR adds `util.Stat` function that returns `os.FileInfo` by calling `Stat` on `billy.File` underlying type.