### PR TITLE
File read-able check should ignore file creation flags

### DIFF
--- a/memfs/memory.go
+++ b/memfs/memory.go
@@ -229,7 +229,7 @@ func (f *file) ReadAt(b []byte, off int64) (int, error) {
 		return 0, os.ErrClosed
 	}
 
-	if !isReadAndWrite(f.flag) && !isReadOnly(f.flag) {
+	if isWriteOnly(f.flag) {
 		return 0, errors.New("read not supported")
 	}
 

--- a/test/basic.go
+++ b/test/basic.go
@@ -116,6 +116,12 @@ func (s *BasicSuite) TestOpenFile(c *C) {
 	c.Assert(f.Name(), Equals, "foo1")
 	s.testReadClose(c, f, "foo1overwritten")
 
+	// Read-only if it exists
+	f, err = s.FS.OpenFile("foo1", os.O_RDONLY|os.O_CREATE, defaultMode)
+	c.Assert(err, IsNil)
+	c.Assert(f.Name(), Equals, "foo1")
+	s.testReadClose(c, f, "foo1overwritten")
+
 	// Create when it does exist
 	f, err = s.FS.OpenFile("foo1", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, defaultMode)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
currently you'll get an error when you try to read from a file which was opened
using a mode like O_RDONLY | O_CREATE, because the check for "is this file
read-able" checks for `((flags | O_RDWR) || flags == 0)`.

With this change, all we check for is that the file was not opened with O_WRONLY. 

Flags like O_CREATE and O_TRUNCATE don't actually impact the access
that a process can have to an open file. When checking whether
a process has read access, all that really matters is that the
file isn't opened with O_WRONLY.