### PR TITLE
memfs: ReadDir sorted by filename

### DIFF
--- a/memfs/memory.go
+++ b/memfs/memory.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -117,6 +118,12 @@ func (fs *Memory) Lstat(filename string) (os.FileInfo, error) {
 	return f.Stat()
 }
 
+type ByName []os.FileInfo
+
+func (a ByName) Len() int           { return len(a) }
+func (a ByName) Less(i, j int) bool { return a[i].Name() < a[j].Name() }
+func (a ByName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+
 func (fs *Memory) ReadDir(path string) ([]os.FileInfo, error) {
 	if f, has := fs.s.Get(path); has {
 		if target, isLink := fs.resolveLink(path, f); isLink {
@@ -129,6 +136,8 @@ func (fs *Memory) ReadDir(path string) ([]os.FileInfo, error) {
 		fi, _ := f.Stat()
 		entries = append(entries, fi)
 	}
+
+	sort.Sort(ByName(entries))
 
 	return entries, nil
 }

--- a/memfs/memory_test.go
+++ b/memfs/memory_test.go
@@ -44,3 +44,27 @@ func (s *MemorySuite) TestNegativeOffsets(c *C) {
 	_, err = f.Write(buf)
 	c.Assert(err, ErrorMatches, "writeat negative: negative offset")
 }
+
+func (s *MemorySuite) TestOrder(c *C) {
+	var err error
+
+	files := []string{
+		"a",
+		"b",
+		"c",
+	}
+	for _, f := range files {
+		_, err = s.FS.Create(f)
+		c.Assert(err, IsNil)
+	}
+
+	attemps := 30
+	for n := 0; n < attemps; n++ {
+		actual, err := s.FS.ReadDir("")
+		c.Assert(err, IsNil)
+
+		for i, f := range files {
+			c.Assert(actual[i].Name(), Equals, f)
+		}
+	}
+}


### PR DESCRIPTION
This request ensures the order returned by ReadDir for memfs.

The entries are sorted lexicographically because this is how to strings are automatically sorted, The interface does not specify how the filename is sorted, but I think it makes sense to use the default behavior. 

```go
type Dir interface {
	// ReadDir reads the directory named by dirname and returns a list of
	// directory entries sorted by filename.
	ReadDir(path string) ([]os.FileInfo, error)
}
```

Reference: https://golang.org/src/strings/compare.go