### PR TITLE
Support build / run under wasm / gopherjs

### DIFF
--- a/osfs/os.go
+++ b/osfs/os.go
@@ -1,3 +1,5 @@
+// +build !js
+
 // Package osfs provides a billy filesystem for the OS.
 package osfs // import "github.com/go-git/go-billy/v5/osfs"
 

--- a/osfs/os_js.go
+++ b/osfs/os_js.go
@@ -1,0 +1,23 @@
+package osfs
+
+import (
+	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/helper/chroot"
+	"github.com/go-git/go-billy/v5/memfs"
+)
+
+// globalMemFs is the global memory fs
+var globalMemFs = memfs.New()
+
+const (
+	defaultDirectoryMode = 0755
+	defaultCreateMode    = 0666
+)
+
+// OS is a filesystem shim for js.
+type OS struct{}
+
+// New returns a new OS filesystem.
+func New(baseDir string) billy.Filesystem {
+	return chroot.New(globalMemFs, baseDir)
+}

--- a/osfs/os_posix.go
+++ b/osfs/os_posix.go
@@ -1,4 +1,4 @@
-// +build !plan9,!windows
+// +build !plan9,!windows,!js
 
 package osfs
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/534887/115309330-f8323f00-a120-11eb-81e6-301443602998.png)

Uses a in-memory tree when osfs would otherwise be used.