### PR TITLE
Remove import path checking

### DIFF
--- a/memfs/memory.go
+++ b/memfs/memory.go
@@ -1,5 +1,5 @@
 // Package memfs provides a billy filesystem base on memory.
-package memfs // import "github.com/go-git/go-billy/v5/memfs"
+package memfs
 
 import (
 	"errors"

--- a/osfs/os.go
+++ b/osfs/os.go
@@ -1,7 +1,7 @@
 // +build !js
 
 // Package osfs provides a billy filesystem for the OS.
-package osfs // import "github.com/go-git/go-billy/v5/osfs"
+package osfs
 
 import (
 	"io/ioutil"


### PR DESCRIPTION
As raised in #3, right now this project can't be used without Go modules because of the presence of these [import comments](https://pkg.go.dev/cmd/go#hdr-Import_path_checking), in contrast with what is described in the README. This fixes the issue by just removing the comments.