### PR TITLE
Re-introduce osfs.Default

### DIFF
--- a/osfs/os.go
+++ b/osfs/os.go
@@ -18,6 +18,9 @@ const (
 	defaultCreateMode    = 0o666
 )
 
+// Default Filesystem representing the root of the os filesystem.
+var Default = &ChrootOS{}
+
 // New returns a new OS filesystem.
 func New(baseDir string, opts ...Option) billy.Filesystem {
 	o := &options{}

--- a/osfs/os_js_test.go
+++ b/osfs/os_js_test.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/helper/chroot"
 	"github.com/go-git/go-billy/v5/test"
 
 	. "gopkg.in/check.v1"
@@ -45,4 +47,17 @@ func (s *OSSuite) TestCapabilities(c *C) {
 
 	caps := billy.Capabilities(s.FS)
 	c.Assert(caps, Equals, billy.DefaultCapabilities&^billy.LockCapability)
+}
+
+func TestDefault(t *testing.T) {
+	want := &chroot.ChrootHelper{} // memfs is wrapped around ChrootHelper.
+	got := Default
+
+	if reflect.TypeOf(got) != reflect.TypeOf(want) {
+		t.Errorf("wanted Default to be %T got %T", want, got)
+	}
+}
+
+func TestNewAPI(t *testing.T) {
+	_ = New("/")
 }

--- a/osfs/os_test.go
+++ b/osfs/os_test.go
@@ -1,0 +1,24 @@
+//go:build !js
+// +build !js
+
+package osfs
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDefault(t *testing.T) {
+	want := &ChrootOS{}
+	got := Default
+
+	if reflect.TypeOf(got) != reflect.TypeOf(want) {
+		t.Errorf("wanted Default to be %T got %T", want, got)
+	}
+}
+
+func TestNewAPI(t *testing.T) {
+	_ = New("/")
+	_ = New("/", WithBoundOS())
+	_ = New("/", WithChrootOS())
+}


### PR DESCRIPTION
The `Default` var was incorrectly removed as part of #31. This PR revert that change and adds tests to avoid future regression.