### PR TITLE
add stubs to allow compilation under GOOS=tamago

### DIFF
--- a/osfs/os.go
+++ b/osfs/os.go
@@ -1,4 +1,4 @@
-// +build !js
+// +build !js,!tamago
 
 // Package osfs provides a billy filesystem for the OS.
 package osfs // import "github.com/go-git/go-billy/v5/osfs"

--- a/osfs/os_posix.go
+++ b/osfs/os_posix.go
@@ -1,4 +1,4 @@
-// +build !plan9,!windows,!js
+// +build !plan9,!windows,!js,!tamago
 
 package osfs
 

--- a/osfs/os_tamago.go
+++ b/osfs/os_tamago.go
@@ -1,0 +1,21 @@
+// +build tamago
+
+package osfs
+
+import (
+	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/helper/chroot"
+	"github.com/go-git/go-billy/v5/memfs"
+)
+
+// globalMemFs is the global memory fs
+var globalMemFs = memfs.New()
+
+// Default Filesystem representing the root of in-memory filesystem for a
+// js/wasm environment.
+var Default = memfs.New()
+
+// New returns a new OS filesystem.
+func New(baseDir string) billy.Filesystem {
+	return chroot.New(Default, Default.Join("/", baseDir))
+}


### PR DESCRIPTION
The [TamaGo bare metal framework](https://github.com/usbarmory/tamago) would benefit from being able to integrate go-git on bare metal firmware.

This PR, in combination with this [go-git PR](https://github.com/go-git/go-git/pull/1016) adds the required stubs to allow compilation under GOOS=tamago.

Thanks
