### PR TITLE
fix: memfs Rename() issue

### DIFF
--- a/memfs/storage.go
+++ b/memfs/storage.go
@@ -138,7 +138,6 @@ func (s *storage) Rename(from, to string) error {
 func (s *storage) move(from, to string) error {
 	s.files[to] = s.files[from]
 	s.files[to].name = filepath.Base(to)
-	s.children[to] = s.children[from]
 
 	defer func() {
 		delete(s.children, from)


### PR DESCRIPTION
Fix the following issues:
  - After renaming, it adds an entry for each regular files in the _s.children_ map, which should actually only contain directories
  - Even worse, any child files in a directory that are renamed before the directory itself will be lost when the directory is renamed.

Since the _createParent_ method is called at the end of the _move_ method, the directory structure is automatically updated when the files are renamed. Assigning the old value of _s.children_ to the new value does nothing to help except create the issues described above.