### PR TITLE
Add wrapper for io/fs

### DIFF
--- a/helper/iofs/iofs.go
+++ b/helper/iofs/iofs.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Wrap adapts a billy.Filesystem to a io.fs.FS.
-func Wrap(fs billyfs.Basic) fs.FS {
+func New(fs billyfs.Basic) fs.FS {
 	return &adapterFs{fs: polyfill.New(fs)}
 }
 

--- a/helper/iofs/iofs.go
+++ b/helper/iofs/iofs.go
@@ -20,18 +20,19 @@ type adapterFs struct {
 	fs billyfs.Filesystem
 }
 
+// Type assertion that adapterFS implements the following interfaces:
 var _ fs.FS = (*adapterFs)(nil)
 var _ fs.ReadDirFS = (*adapterFs)(nil)
 var _ fs.StatFS = (*adapterFs)(nil)
 var _ fs.ReadFileFS = (*adapterFs)(nil)
 
-// GlobFS would be harder, we don't implement for now.
+// TODO: implement fs.GlobFS, which will be a fair bit more code.
 
-// Open implements fs.FS.
+// Open opens the named file on the underlying FS, implementing fs.FS (returning a file or error).
 func (a *adapterFs) Open(name string) (fs.File, error) {
 	if name[0] == '/' || name != filepath.Clean(name) {
-		// fstest.TestFS explicitly checks that these should return error
-		// MemFS is performs the clean internally, so we need to block that here for testing.
+		// fstest.TestFS explicitly checks that these should return error.
+		// MemFS performs the clean internally, so we need to block that here for testing purposes.
 		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
 	}
 	stat, err := a.fs.Stat(name)
@@ -49,7 +50,7 @@ func (a *adapterFs) Open(name string) (fs.File, error) {
 	return &adapterFile{file: file, info: stat}, err
 }
 
-// ReadDir implements fs.ReadDirFS.
+// ReadDir reads the named directory, implementing fs.ReadDirFS (returning a listing or error).
 func (a *adapterFs) ReadDir(name string) ([]fs.DirEntry, error) {
 	items, err := a.fs.ReadDir(name)
 	if err != nil {
@@ -62,12 +63,12 @@ func (a *adapterFs) ReadDir(name string) ([]fs.DirEntry, error) {
 	return entries, nil
 }
 
-// Stat implements fs.StatFS.
+// Stat returns information on the named file, implementing fs.StatFS (returning FileInfo or error).
 func (a *adapterFs) Stat(name string) (fs.FileInfo, error) {
 	return a.fs.Stat(name)
 }
 
-// ReadFile implements fs.ReadFileFS.
+// ReadFile reads the named file and returns its contents, implementing fs.ReadFileFS (returning contents or error).
 func (a *adapterFs) ReadFile(name string) ([]byte, error) {
 	stat, err := a.fs.Stat(name)
 	if err != nil {
@@ -90,17 +91,17 @@ type adapterFile struct {
 
 var _ fs.File = (*adapterFile)(nil)
 
-// Close implements fs.File.
+// Close closes the file, implementing fs.File (and io.Closer).
 func (a *adapterFile) Close() error {
 	return a.file.Close()
 }
 
-// Read implements fs.File.
+// Read reads bytes from the file, implementing fs.File (and io.Reader).
 func (a *adapterFile) Read(b []byte) (int, error) {
 	return a.file.Read(b)
 }
 
-// Stat implements fs.File.
+// Stat returns file information, implementing fs.File (returning FileInfo or error).
 func (a *adapterFile) Stat() (fs.FileInfo, error) {
 	return a.info, nil
 }
@@ -119,21 +120,18 @@ func makeDir(stat fs.FileInfo, entries []fs.DirEntry) *adapterDirFile {
 	}
 }
 
-// Close implements fs.File.
+// Close closes the directory, implementing fs.File (and io.Closer).
 // Subtle: note that this is shadowing adapterFile.Close.
 func (a *adapterDirFile) Close() error {
 	return nil
 }
 
-// ReadDir implements fs.ReadDirFile.
+// ReadDir reads the directory contents, implementing fs.ReadDirFile (returning directory listing or error).
 func (a *adapterDirFile) ReadDir(n int) ([]fs.DirEntry, error) {
 	if len(a.entries) == 0 && n > 0 {
 		return nil, io.EOF
 	}
-	if n <= 0 {
-		n = len(a.entries)
-	}
-	if n > len(a.entries) {
+	if n <= 0 || n > len(a.entries) {
 		n = len(a.entries)
 	}
 	entries := a.entries[:n]

--- a/helper/iofs/iofs.go
+++ b/helper/iofs/iofs.go
@@ -1,0 +1,142 @@
+// Package iofs provides an adapter from billy.Filesystem to a the
+// standard library io.fs.FS interface.
+package iofs
+
+import (
+	"io"
+	"io/fs"
+	"path/filepath"
+
+	billyfs "github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/helper/polyfill"
+)
+
+// Wrap adapts a billy.Filesystem to a io.fs.FS.
+func Wrap(fs billyfs.Basic) fs.FS {
+	return &adapterFs{fs: polyfill.New(fs)}
+}
+
+type adapterFs struct {
+	fs billyfs.Filesystem
+}
+
+var _ fs.FS = (*adapterFs)(nil)
+var _ fs.ReadDirFS = (*adapterFs)(nil)
+var _ fs.StatFS = (*adapterFs)(nil)
+var _ fs.ReadFileFS = (*adapterFs)(nil)
+
+// GlobFS would be harder, we don't implement for now.
+
+// Open implements fs.FS.
+func (a *adapterFs) Open(name string) (fs.File, error) {
+	if name[0] == '/' || name != filepath.Clean(name) {
+		// fstest.TestFS explicitly checks that these should return error
+		// MemFS is performs the clean internally, so we need to block that here for testing.
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+	}
+	stat, err := a.fs.Stat(name)
+	if err != nil {
+		return nil, err
+	}
+	if stat.IsDir() {
+		entries, err := a.ReadDir(name)
+		if err != nil {
+			return nil, err
+		}
+		return makeDir(stat, entries), nil
+	}
+	file, err := a.fs.Open(name)
+	return &adapterFile{file: file, info: stat}, err
+}
+
+// ReadDir implements fs.ReadDirFS.
+func (a *adapterFs) ReadDir(name string) ([]fs.DirEntry, error) {
+	items, err := a.fs.ReadDir(name)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]fs.DirEntry, len(items))
+	for i, item := range items {
+		entries[i] = fs.FileInfoToDirEntry(item)
+	}
+	return entries, nil
+}
+
+// Stat implements fs.StatFS.
+func (a *adapterFs) Stat(name string) (fs.FileInfo, error) {
+	return a.fs.Stat(name)
+}
+
+// ReadFile implements fs.ReadFileFS.
+func (a *adapterFs) ReadFile(name string) ([]byte, error) {
+	stat, err := a.fs.Stat(name)
+	if err != nil {
+		return nil, err
+	}
+	b := make([]byte, stat.Size())
+	file, err := a.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	_, err = file.Read(b)
+	return b, err
+}
+
+type adapterFile struct {
+	file billyfs.File
+	info fs.FileInfo
+}
+
+var _ fs.File = (*adapterFile)(nil)
+
+// Close implements fs.File.
+func (a *adapterFile) Close() error {
+	return a.file.Close()
+}
+
+// Read implements fs.File.
+func (a *adapterFile) Read(b []byte) (int, error) {
+	return a.file.Read(b)
+}
+
+// Stat implements fs.File.
+func (a *adapterFile) Stat() (fs.FileInfo, error) {
+	return a.info, nil
+}
+
+type adapterDirFile struct {
+	adapterFile
+	entries []fs.DirEntry
+}
+
+var _ fs.ReadDirFile = (*adapterDirFile)(nil)
+
+func makeDir(stat fs.FileInfo, entries []fs.DirEntry) *adapterDirFile {
+	return &adapterDirFile{
+		adapterFile: adapterFile{info: stat},
+		entries:     entries,
+	}
+}
+
+// Close implements fs.File.
+// Subtle: note that this is shadowing adapterFile.Close.
+func (a *adapterDirFile) Close() error {
+	return nil
+}
+
+// ReadDir implements fs.ReadDirFile.
+func (a *adapterDirFile) ReadDir(n int) ([]fs.DirEntry, error) {
+	if len(a.entries) == 0 && n > 0 {
+		return nil, io.EOF
+	}
+	if n <= 0 {
+		n = len(a.entries)
+	}
+	if n > len(a.entries) {
+		n = len(a.entries)
+	}
+	entries := a.entries[:n]
+	a.entries = a.entries[n:]
+	return entries, nil
+}

--- a/helper/iofs/iofs_test.go
+++ b/helper/iofs/iofs_test.go
@@ -21,21 +21,25 @@ type wrappedError interface {
 	Unwrap() error
 }
 
-// TestWithFSTest leverages the packaged Go fstest package, which seems comprehensive
+// TestWithFSTest leverages the packaged Go fstest package, which seems comprehensive.
 func TestWithFSTest(t *testing.T) {
 	t.Parallel()
 	memfs := memfs.New()
 	iofs := Wrap(memfs)
 
 	files := map[string]string{
-		"foo.txt":     "hello, world",
-		"bar.txt":     "goodbye, world",
-		"dir/baz.txt": "こんにちわ, world",
+		"foo.txt":                       "hello, world",
+		"bar.txt":                       "goodbye, world",
+		filepath.Join("dir", "baz.txt"): "こんにちわ, world",
 	}
 	created_files := make([]string, 0, len(files))
 	for filename, contents := range files {
 		makeFile(memfs, t, filename, contents)
 		created_files = append(created_files, filename)
+	}
+
+	if runtime.GOOS == "windows" {
+		t.Skip("fstest.TestFS is not yet windows path aware")
 	}
 
 	err := fstest.TestFS(iofs, created_files...)

--- a/helper/iofs/iofs_test.go
+++ b/helper/iofs/iofs_test.go
@@ -25,7 +25,7 @@ type wrappedError interface {
 func TestWithFSTest(t *testing.T) {
 	t.Parallel()
 	memfs := memfs.New()
-	iofs := Wrap(memfs)
+	iofs := New(memfs)
 
 	files := map[string]string{
 		"foo.txt":                       "hello, world",
@@ -51,7 +51,7 @@ func TestWithFSTest(t *testing.T) {
 func TestDeletes(t *testing.T) {
 	t.Parallel()
 	memfs := memfs.New()
-	iofs := Wrap(memfs).(fs.ReadFileFS)
+	iofs := New(memfs).(fs.ReadFileFS)
 
 	makeFile(memfs, t, "foo.txt", "hello, world")
 	makeFile(memfs, t, "deleted", "nothing to see")

--- a/helper/iofs/iofs_test.go
+++ b/helper/iofs/iofs_test.go
@@ -1,0 +1,102 @@
+package iofs
+
+import (
+	"errors"
+	"io/fs"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	billyfs "github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/memfs"
+)
+
+type errorList interface {
+	Unwrap() []error
+}
+
+type wrappedError interface {
+	Unwrap() error
+}
+
+// TestWithFSTest leverages the packaged Go fstest package, which seems comprehensive
+func TestWithFSTest(t *testing.T) {
+	t.Parallel()
+	memfs := memfs.New()
+	iofs := Wrap(memfs)
+
+	files := map[string]string{
+		"foo.txt":     "hello, world",
+		"bar.txt":     "goodbye, world",
+		"dir/baz.txt": "こんにちわ, world",
+	}
+	created_files := make([]string, 0, len(files))
+	for filename, contents := range files {
+		makeFile(memfs, t, filename, contents)
+		created_files = append(created_files, filename)
+	}
+
+	err := fstest.TestFS(iofs, created_files...)
+	if err != nil {
+		if unwrapped := errors.Unwrap(err); unwrapped != nil {
+			err = unwrapped
+		}
+		if errs, ok := err.(errorList); ok {
+			for _, e := range errs.Unwrap() {
+
+				if strings.Contains(e.Error(), "ModTime") {
+					// Memfs returns the current time for Stat().ModTime(), which triggers
+					// a diff complaint in fstest.  We can ignore this, or store modtimes
+					// for every file in Memfs (at a cost of 16 bytes / file).
+					t.Log("Skipping ModTime error (ok).")
+				} else {
+					t.Errorf("Unexpected fstest error: %v", e)
+				}
+			}
+		} else {
+			t.Fatalf("Failed to test fs:\n%v", err)
+		}
+	}
+}
+
+func TestDeletes(t *testing.T) {
+	t.Parallel()
+	memfs := memfs.New()
+	iofs := Wrap(memfs).(fs.ReadFileFS)
+
+	makeFile(memfs, t, "foo.txt", "hello, world")
+	makeFile(memfs, t, "deleted", "nothing to see")
+
+	if _, err := iofs.ReadFile("nonexistent"); err == nil {
+		t.Errorf("expected error for nonexistent file")
+	}
+
+	data, err := iofs.ReadFile("deleted")
+	if err != nil {
+		t.Fatalf("failed to read file before delete: %v", err)
+	}
+	if string(data) != "nothing to see" {
+		t.Errorf("unexpected contents before delete: %v", data)
+	}
+
+	if err := memfs.Remove("deleted"); err != nil {
+		t.Fatalf("failed to remove file: %v", err)
+	}
+
+	if _, err = iofs.ReadFile("deleted"); err == nil {
+		t.Errorf("file existed after delete!")
+	}
+}
+
+func makeFile(fs billyfs.Basic, t *testing.T, filename string, contents string) {
+	t.Helper()
+	file, err := fs.Create(filename)
+	if err != nil {
+		t.Fatalf("failed to create file %s: %v", filename, err)
+	}
+	defer file.Close()
+	_, err = file.Write([]byte(contents))
+	if err != nil {
+		t.Fatalf("failed to write to file %s: %v", filename, err)
+	}
+}


### PR DESCRIPTION
Fixes #11

I did not implement `SubFS` or `GlobFS`, because those seemed a bit trickier, and I didn't need them for my use case.  :grin:  Another option would be to extend the `billy.File` interface to add a `Stat()` method, but that seemed like a breaking ("v6") change, at which point you might simply want to rewrite towards `io/fs`, which has a testing memory filesystem already.

It turns out that the Go `fstest.TestFS` is a bit more stringent than the billy tests,
and it checks to see whether two `Stat()` calls return the same results on the same file.  I disabled those tests in the unit test, but we could also adjust the Memfs implementation to store the ModTimes on each file when they are created.  I thought the extra in-memory storage probably wasn't worth it, but I have a patch if you'd prefer that approach.

```
ok  	github.com/go-git/go-billy/v5/helper/iofs	0.244s	coverage: 93.3% of statements
```

Note that you'll probably need Go 1.23.x to pick up [this change](https://cs.opensource.google/go/go/+/74cce866f865c3188a34309e4ebc7a5c9ed0683d) to the errors returned by `fstest.TestFS()`.
