### PR TITLE
memfs: Add deterministic modification times

### DIFF
--- a/memfs/memory_test.go
+++ b/memfs/memory_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRootExists(t *testing.T) {
@@ -26,6 +27,35 @@ func TestCapabilities(t *testing.T) {
 
 	caps := billy.Capabilities(fs)
 	assert.Equal(t, billy.DefaultCapabilities&^billy.LockCapability, caps)
+}
+
+func TestModTime(t *testing.T) {
+	fs := New()
+	_, err := fs.Create("/file1")
+	require.NoError(t, err)
+
+	_, err = fs.Create("/file2")
+	require.NoError(t, err)
+
+	fi1a, err := fs.Stat("/file1")
+	require.NoError(t, err)
+
+	fi2, err := fs.Stat("/file2")
+	require.NoError(t, err)
+
+	fi1b, err := fs.Stat("/file1")
+	require.NoError(t, err)
+
+	modtime := fi1a.ModTime()
+
+	// file 1 and file 2 should have different mod times.
+	assert.NotEqual(t, modtime, fi2.ModTime())
+
+	// a new file info for the same unmodified file, should still match mod time.
+	assert.Equal(t, modtime, fi1b.ModTime())
+
+	// new calls to ModTime() retain existing mod time.
+	assert.Equal(t, modtime, fi1a.ModTime())
 }
 
 func TestNegativeOffsets(t *testing.T) {

--- a/memfs/memory_test.go
+++ b/memfs/memory_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/util"
@@ -33,6 +34,10 @@ func TestModTime(t *testing.T) {
 	fs := New()
 	_, err := fs.Create("/file1")
 	require.NoError(t, err)
+
+	if runtime.GOOS == "windows" {
+		time.Sleep(20 * time.Millisecond)
+	}
 
 	_, err = fs.Create("/file2")
 	require.NoError(t, err)

--- a/memfs/storage.go
+++ b/memfs/storage.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 )
 
 type storage struct {
@@ -46,6 +47,7 @@ func (s *storage) New(path string, mode os.FileMode, flag int) (*file, error) {
 		content: &content{name: name},
 		mode:    mode,
 		flag:    flag,
+		modTime: time.Now(),
 	}
 
 	s.files[path] = f


### PR DESCRIPTION
Memfs returns the latest time on every invocation of ModTime(), which causes issues in go-git when an accurate modification time is required.

Relates to https://github.com/go-git/go-git/issues/1342, when using the latest version of go-git-fixtures.