### PR TITLE
Enable the `iofs` adapter to also return other interfaces from `io/fs`

### DIFF
--- a/helper/iofs/iofs.go
+++ b/helper/iofs/iofs.go
@@ -16,6 +16,21 @@ func New(fs billyfs.Basic) fs.FS {
 	return &adapterFs{fs: polyfill.New(fs)}
 }
 
+// NewStatFS adapts a billy.Filesystem to a io.fs.StatFS.
+func NewStatFS(fs billyfs.Basic) fs.StatFS {
+	return &adapterFs{fs: polyfill.New(fs)}
+}
+
+// NewReadDirFS adapts a billy.Filesystem to a io.fs.ReadDirFS.
+func NewReadDirFS(fs billyfs.Basic) fs.ReadDirFS {
+	return &adapterFs{fs: polyfill.New(fs)}
+}
+
+// NewReadFileFS adapts a billy.Filesystem to a io.fs.ReadFileFS.
+func NewReadFileFS(fs billyfs.Basic) fs.ReadFileFS {
+	return &adapterFs{fs: polyfill.New(fs)}
+}
+
 type adapterFs struct {
 	fs billyfs.Filesystem
 }


### PR DESCRIPTION
Instead of relying on difficult casting, this improves developer
experience by providing easy ways of convering a billy filesystem into
the rest of the filesystem interfaces that are available in `io/fs`.

This is a safe operation since we already ensure the type implements
such interfaces some lines below my changes.
