### PR TITLE
Bump module to v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# go-billy [![GoDoc](https://godoc.org/gopkg.in/go-git/go-billy.v5?status.svg)](https://pkg.go.dev/github.com/go-git/go-billy/v5) [![Test](https://github.com/go-git/go-billy/workflows/Test/badge.svg)](https://github.com/go-git/go-billy/actions?query=workflow%3ATest)
+# go-billy [![GoDoc](https://godoc.org/gopkg.in/go-git/go-billy.v6?status.svg)](https://pkg.go.dev/github.com/go-git/go-billy/v6) [![Test](https://github.com/go-git/go-billy/workflows/Test/badge.svg)](https://github.com/go-git/go-billy/actions?query=workflow%3ATest)
 
 The missing interface filesystem abstraction for Go.
 Billy implements an interface based on the `os` standard library, allowing to develop applications without dependency on the underlying storage. Makes it virtually free to implement mocks and testing over filesystem operations.
@@ -8,14 +8,14 @@ Billy was born as part of [go-git/go-git](https://github.com/go-git/go-git) proj
 ## Installation
 
 ```go
-import "github.com/go-git/go-billy/v5" // with go modules enabled (GO111MODULE=on or outside GOPATH)
+import "github.com/go-git/go-billy/v6" // with go modules enabled (GO111MODULE=on or outside GOPATH)
 import "github.com/go-git/go-billy" // with go modules disabled
 ```
 
 ## Usage
 
 Billy exposes filesystems using the
-[`Filesystem` interface](https://pkg.go.dev/github.com/go-git/go-billy/v5?tab=doc#Filesystem).
+[`Filesystem` interface](https://pkg.go.dev/github.com/go-git/go-billy/v6?tab=doc#Filesystem).
 Each filesystem implementation gives you a `New` method, whose arguments depend on
 the implementation itself, that returns a new `Filesystem`.
 

--- a/fs.go
+++ b/fs.go
@@ -166,8 +166,7 @@ type File interface {
 	// Name returns the name of the file as presented to Open.
 	Name() string
 	io.Writer
-	// TODO: Add io.WriterAt for v6
-	// io.WriterAt
+	io.WriterAt
 	io.ReaderAt
 	io.Seeker
 	// Lock locks the file like e.g. flock. It protects against access from

--- a/fs.go
+++ b/fs.go
@@ -3,6 +3,7 @@ package billy
 import (
 	"errors"
 	"io"
+	"io/fs"
 	"os"
 	"time"
 )
@@ -161,15 +162,15 @@ type Chroot interface {
 
 // File represent a file, being a subset of the os.File
 type File interface {
+	fs.File
+
 	// Name returns the name of the file as presented to Open.
 	Name() string
 	io.Writer
-	// TODO: Add io.WriterAt for v6  
+	// TODO: Add io.WriterAt for v6
 	// io.WriterAt
-	io.Reader
 	io.ReaderAt
 	io.Seeker
-	io.Closer
 	// Lock locks the file like e.g. flock. It protects against access from
 	// other processes.
 	Lock() error

--- a/fs.go
+++ b/fs.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"io"
 	"io/fs"
-	"os"
 	"time"
 )
 
@@ -73,9 +72,9 @@ type Basic interface {
 	// instead. It opens the named file with specified flag (O_RDONLY etc.) and
 	// perm, (0666 etc.) if applicable. If successful, methods on the returned
 	// File can be used for I/O.
-	OpenFile(filename string, flag int, perm os.FileMode) (File, error)
+	OpenFile(filename string, flag int, perm fs.FileMode) (File, error)
 	// Stat returns a FileInfo describing the named file.
-	Stat(filename string) (os.FileInfo, error)
+	Stat(filename string) (fs.FileInfo, error)
 	// Rename renames (moves) oldpath to newpath. If newpath already exists and
 	// is not a directory, Rename replaces it. OS-specific restrictions may
 	// apply when oldpath and newpath are in different directories.
@@ -106,12 +105,12 @@ type TempFile interface {
 type Dir interface {
 	// ReadDir reads the directory named by dirname and returns a list of
 	// directory entries sorted by filename.
-	ReadDir(path string) ([]os.FileInfo, error)
+	ReadDir(path string) ([]fs.FileInfo, error)
 	// MkdirAll creates a directory named path, along with any necessary
 	// parents, and returns nil, or else returns an error. The permission bits
 	// perm are used for all directories that MkdirAll creates. If path is/
 	// already a directory, MkdirAll does nothing and returns nil.
-	MkdirAll(filename string, perm os.FileMode) error
+	MkdirAll(filename string, perm fs.FileMode) error
 }
 
 // Symlink abstract the symlink related operations in a storage-agnostic
@@ -120,7 +119,7 @@ type Symlink interface {
 	// Lstat returns a FileInfo describing the named file. If the file is a
 	// symbolic link, the returned FileInfo describes the symbolic link. Lstat
 	// makes no attempt to follow the link.
-	Lstat(filename string) (os.FileInfo, error)
+	Lstat(filename string) (fs.FileInfo, error)
 	// Symlink creates a symbolic-link from link to target. target may be an
 	// absolute or relative path, and need not refer to an existing node.
 	// Parent directories of link are created as necessary.
@@ -134,7 +133,7 @@ type Symlink interface {
 type Change interface {
 	// Chmod changes the mode of the named file to mode. If the file is a
 	// symbolic link, it changes the mode of the link's target.
-	Chmod(name string, mode os.FileMode) error
+	Chmod(name string, mode fs.FileMode) error
 	// Lchown changes the numeric uid and gid of the named file. If the file is
 	// a symbolic link, it changes the uid and gid of the link itself.
 	Lchown(name string, uid, gid int) error

--- a/fs_test.go
+++ b/fs_test.go
@@ -3,8 +3,8 @@ package billy_test
 import (
 	"testing"
 
-	. "github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/internal/test"
+	. "github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/internal/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-git/go-billy/v5
+module github.com/go-git/go-billy/v6
 
 // go-git supports the last 3 stable Go versions.
 go 1.21

--- a/helper/chroot/chroot.go
+++ b/helper/chroot/chroot.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/helper/polyfill"
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/helper/polyfill"
 )
 
 // ChrootHelper is a helper to implement billy.Chroot.

--- a/helper/chroot/chroot.go
+++ b/helper/chroot/chroot.go
@@ -1,6 +1,7 @@
 package chroot
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -68,7 +69,7 @@ func (fs *ChrootHelper) Open(filename string) (billy.File, error) {
 	return newFile(fs, f, filename), nil
 }
 
-func (fs *ChrootHelper) OpenFile(filename string, flag int, mode os.FileMode) (billy.File, error) {
+func (fs *ChrootHelper) OpenFile(filename string, flag int, mode fs.FileMode) (billy.File, error) {
 	fullpath, err := fs.underlyingPath(filename)
 	if err != nil {
 		return nil, err
@@ -142,7 +143,7 @@ func (fs *ChrootHelper) ReadDir(path string) ([]os.FileInfo, error) {
 	return fs.underlying.(billy.Dir).ReadDir(fullpath)
 }
 
-func (fs *ChrootHelper) MkdirAll(filename string, perm os.FileMode) error {
+func (fs *ChrootHelper) MkdirAll(filename string, perm fs.FileMode) error {
 	fullpath, err := fs.underlyingPath(filename)
 	if err != nil {
 		return err

--- a/helper/chroot/chroot_test.go
+++ b/helper/chroot/chroot_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/internal/test"
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/internal/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/helper/iofs/iofs.go
+++ b/helper/iofs/iofs.go
@@ -7,8 +7,8 @@ import (
 	"io/fs"
 	"path/filepath"
 
-	billyfs "github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/helper/polyfill"
+	billyfs "github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/helper/polyfill"
 )
 
 // Wrap adapts a billy.Filesystem to a io.fs.FS.

--- a/helper/iofs/iofs_test.go
+++ b/helper/iofs/iofs_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"testing/fstest"
 
-	billyfs "github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/memfs"
+	billyfs "github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/memfs"
 )
 
 type errorList interface {

--- a/helper/mount/mount.go
+++ b/helper/mount/mount.go
@@ -2,6 +2,7 @@ package mount
 
 import (
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -53,7 +54,7 @@ func (h *Mount) Open(path string) (billy.File, error) {
 	return wrapFile(f, path), err
 }
 
-func (h *Mount) OpenFile(path string, flag int, mode os.FileMode) (billy.File, error) {
+func (h *Mount) OpenFile(path string, flag int, mode fs.FileMode) (billy.File, error) {
 	fs, fullpath := h.getBasicAndPath(path)
 	if fullpath == "." {
 		return nil, os.ErrInvalid
@@ -118,7 +119,7 @@ func (h *Mount) ReadDir(path string) ([]os.FileInfo, error) {
 	return fs.ReadDir(fullpath)
 }
 
-func (h *Mount) MkdirAll(filename string, perm os.FileMode) error {
+func (h *Mount) MkdirAll(filename string, perm fs.FileMode) error {
 	fs, fullpath, err := h.getDirAndPath(filename)
 	if err != nil {
 		return err

--- a/helper/mount/mount.go
+++ b/helper/mount/mount.go
@@ -8,8 +8,8 @@ import (
 
 	"fmt"
 
-	"github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/helper/polyfill"
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/helper/polyfill"
 )
 
 var separator = string(filepath.Separator)

--- a/helper/mount/mount_test.go
+++ b/helper/mount/mount_test.go
@@ -5,10 +5,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/internal/test"
-	"github.com/go-git/go-billy/v5/memfs"
-	"github.com/go-git/go-billy/v5/util"
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/internal/test"
+	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/go-git/go-billy/v6/util"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/helper/polyfill/polyfill.go
+++ b/helper/polyfill/polyfill.go
@@ -1,6 +1,7 @@
 package polyfill
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -47,7 +48,7 @@ func (h *Polyfill) ReadDir(path string) ([]os.FileInfo, error) {
 	return h.Basic.(billy.Dir).ReadDir(path)
 }
 
-func (h *Polyfill) MkdirAll(filename string, perm os.FileMode) error {
+func (h *Polyfill) MkdirAll(filename string, perm fs.FileMode) error {
 	if !h.c.dir {
 		return billy.ErrNotSupported
 	}

--- a/helper/polyfill/polyfill.go
+++ b/helper/polyfill/polyfill.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 )
 
 // Polyfill is a helper that implements all missing method from billy.Filesystem.

--- a/helper/polyfill/polyfill_test.go
+++ b/helper/polyfill/polyfill_test.go
@@ -4,8 +4,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/internal/test"
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/internal/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/helper/temporal/temporal.go
+++ b/helper/temporal/temporal.go
@@ -1,8 +1,8 @@
 package temporal
 
 import (
-	"github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/util"
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/util"
 )
 
 // Temporal is a helper that implements billy.TempFile over any filesystem.

--- a/helper/temporal/temporal_test.go
+++ b/helper/temporal/temporal_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-billy/v6/memfs"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/test/mock.go
+++ b/internal/test/mock.go
@@ -6,7 +6,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 )
 
 type BasicMock struct {

--- a/internal/test/mock.go
+++ b/internal/test/mock.go
@@ -30,7 +30,7 @@ func (fs *BasicMock) Open(filename string) (billy.File, error) {
 	return &FileMock{name: filename}, nil
 }
 
-func (fs *BasicMock) OpenFile(filename string, flag int, mode os.FileMode) (billy.File, error) {
+func (fs *BasicMock) OpenFile(filename string, flag int, mode fs.FileMode) (billy.File, error) {
 	fs.OpenFileArgs = append(fs.OpenFileArgs, [3]interface{}{filename, flag, mode})
 	return &FileMock{name: filename}, nil
 }
@@ -76,7 +76,7 @@ func (fs *DirMock) ReadDir(path string) ([]os.FileInfo, error) {
 	return nil, nil
 }
 
-func (fs *DirMock) MkdirAll(filename string, perm os.FileMode) error {
+func (fs *DirMock) MkdirAll(filename string, perm fs.FileMode) error {
 	fs.MkdirAllArgs = append(fs.MkdirAllArgs, [2]interface{}{filename, perm})
 	return nil
 }

--- a/internal/test/mock.go
+++ b/internal/test/mock.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"bytes"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -133,6 +134,10 @@ func (*FileMock) Lock() error {
 
 func (*FileMock) Unlock() error {
 	return nil
+}
+
+func (*FileMock) Stat() (fs.FileInfo, error) {
+	return nil, nil
 }
 
 func (*FileMock) Truncate(size int64) error {

--- a/memfs/memory.go
+++ b/memfs/memory.go
@@ -1,5 +1,5 @@
 // Package memfs provides a billy filesystem base on memory.
-package memfs // import "github.com/go-git/go-billy/v5/memfs"
+package memfs // import "github.com/go-git/go-billy/v6/memfs"
 
 import (
 	"errors"
@@ -12,9 +12,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/helper/chroot"
-	"github.com/go-git/go-billy/v5/util"
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/helper/chroot"
+	"github.com/go-git/go-billy/v6/util"
 )
 
 const separator = filepath.Separator

--- a/memfs/memory.go
+++ b/memfs/memory.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -43,7 +44,7 @@ func (fs *Memory) Open(filename string) (billy.File, error) {
 	return fs.OpenFile(filename, os.O_RDONLY, 0)
 }
 
-func (fs *Memory) OpenFile(filename string, flag int, perm os.FileMode) (billy.File, error) {
+func (fs *Memory) OpenFile(filename string, flag int, perm fs.FileMode) (billy.File, error) {
 	f, has := fs.s.Get(filename)
 	if !has {
 		if !isCreate(flag) {
@@ -154,7 +155,7 @@ func (fs *Memory) ReadDir(path string) ([]os.FileInfo, error) {
 	return entries, nil
 }
 
-func (fs *Memory) MkdirAll(path string, perm os.FileMode) error {
+func (fs *Memory) MkdirAll(path string, perm fs.FileMode) error {
 	_, err := fs.s.New(path, perm|os.ModeDir, 0)
 	return err
 }
@@ -318,7 +319,7 @@ func (f *file) Truncate(size int64) error {
 	return nil
 }
 
-func (f *file) Duplicate(filename string, mode os.FileMode, flag int) billy.File {
+func (f *file) Duplicate(filename string, mode fs.FileMode, flag int) billy.File {
 	new := &file{
 		name:    filename,
 		content: f.content,
@@ -372,7 +373,7 @@ func (fi *fileInfo) Size() int64 {
 	return int64(fi.size)
 }
 
-func (fi *fileInfo) Mode() os.FileMode {
+func (fi *fileInfo) Mode() fs.FileMode {
 	return fi.mode
 }
 
@@ -424,6 +425,6 @@ func isWriteOnly(flag int) bool {
 	return flag&os.O_WRONLY != 0
 }
 
-func isSymlink(m os.FileMode) bool {
+func isSymlink(m fs.FileMode) bool {
 	return m&os.ModeSymlink != 0
 }

--- a/memfs/memory_test.go
+++ b/memfs/memory_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/util"
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/memfs/memory_test.go
+++ b/memfs/memory_test.go
@@ -3,6 +3,7 @@ package memfs
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"runtime"
 	"testing"
@@ -13,6 +14,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var _ fs.File = &file{}
 
 func TestRootExists(t *testing.T) {
 	fs := New()

--- a/memfs/storage.go
+++ b/memfs/storage.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,7 +31,7 @@ func (s *storage) Has(path string) bool {
 	return ok
 }
 
-func (s *storage) New(path string, mode os.FileMode, flag int) (*file, error) {
+func (s *storage) New(path string, mode fs.FileMode, flag int) (*file, error) {
 	path = clean(path)
 	if s.Has(path) {
 		if !s.MustGet(path).mode.IsDir() {
@@ -55,7 +56,7 @@ func (s *storage) New(path string, mode os.FileMode, flag int) (*file, error) {
 	return f, nil
 }
 
-func (s *storage) createParent(path string, mode os.FileMode, f *file) error {
+func (s *storage) createParent(path string, mode fs.FileMode, f *file) error {
 	base := filepath.Dir(path)
 	base = clean(base)
 	if f.Name() == string(separator) {

--- a/osfs/os.go
+++ b/osfs/os.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"sync"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 )
 
 const (

--- a/osfs/os.go
+++ b/osfs/os.go
@@ -103,7 +103,7 @@ func tempFile(dir, prefix string) (billy.File, error) {
 	return &file{File: f}, nil
 }
 
-func openFile(fn string, flag int, perm os.FileMode, createDir func(string) error) (billy.File, error) {
+func openFile(fn string, flag int, perm fs.FileMode, createDir func(string) error) (billy.File, error) {
 	if flag&os.O_CREATE != 0 {
 		if createDir == nil {
 			return nil, fmt.Errorf("createDir func cannot be nil if file needs to be opened in create mode")

--- a/osfs/os_bound.go
+++ b/osfs/os_bound.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 
 	securejoin "github.com/cyphar/filepath-securejoin"
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 )
 
 var (

--- a/osfs/os_bound.go
+++ b/osfs/os_bound.go
@@ -22,6 +22,7 @@ package osfs
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,7 +60,7 @@ func (fs *BoundOS) Create(filename string) (billy.File, error) {
 	return fs.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, defaultCreateMode)
 }
 
-func (fs *BoundOS) OpenFile(filename string, flag int, perm os.FileMode) (billy.File, error) {
+func (fs *BoundOS) OpenFile(filename string, flag int, perm fs.FileMode) (billy.File, error) {
 	filename = fs.expandDot(filename)
 	fn, err := fs.abs(filename)
 	if err != nil {
@@ -102,7 +103,7 @@ func (fs *BoundOS) Rename(from, to string) error {
 	return os.Rename(f, t)
 }
 
-func (fs *BoundOS) MkdirAll(path string, perm os.FileMode) error {
+func (fs *BoundOS) MkdirAll(path string, perm fs.FileMode) error {
 	path = fs.expandDot(path)
 	dir, err := fs.abs(path)
 	if err != nil {

--- a/osfs/os_bound_test.go
+++ b/osfs/os_bound_test.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/osfs/os_chroot.go
+++ b/osfs/os_chroot.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/helper/chroot"
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/helper/chroot"
 )
 
 // ChrootOS is a legacy filesystem based on a "soft chroot" of the os filesystem.

--- a/osfs/os_chroot.go
+++ b/osfs/os_chroot.go
@@ -4,6 +4,7 @@
 package osfs
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -31,7 +32,7 @@ func (fs *ChrootOS) Create(filename string) (billy.File, error) {
 	return fs.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, defaultCreateMode)
 }
 
-func (fs *ChrootOS) OpenFile(filename string, flag int, perm os.FileMode) (billy.File, error) {
+func (fs *ChrootOS) OpenFile(filename string, flag int, perm fs.FileMode) (billy.File, error) {
 	return openFile(filename, flag, perm, fs.createDir)
 }
 
@@ -58,7 +59,7 @@ func (fs *ChrootOS) Rename(from, to string) error {
 	return rename(from, to)
 }
 
-func (fs *ChrootOS) MkdirAll(path string, perm os.FileMode) error {
+func (fs *ChrootOS) MkdirAll(path string, perm fs.FileMode) error {
 	return os.MkdirAll(path, defaultDirectoryMode)
 }
 

--- a/osfs/os_chroot_test.go
+++ b/osfs/os_chroot_test.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/osfs/os_js.go
+++ b/osfs/os_js.go
@@ -4,9 +4,9 @@
 package osfs
 
 import (
-	"github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/helper/chroot"
-	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/helper/chroot"
+	"github.com/go-git/go-billy/v6/memfs"
 )
 
 // globalMemFs is the global memory fs

--- a/osfs/os_js_test.go
+++ b/osfs/os_js_test.go
@@ -9,8 +9,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/helper/chroot"
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/helper/chroot"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/osfs/os_test.go
+++ b/osfs/os_test.go
@@ -4,9 +4,12 @@
 package osfs
 
 import (
+	"io/fs"
 	"reflect"
 	"testing"
 )
+
+var _ fs.File = &file{}
 
 func TestDefault(t *testing.T) {
 	want := &ChrootOS{}

--- a/osfs/os_wasip1_test.go
+++ b/osfs/os_wasip1_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/util"
+	. "github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/util"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/test/chroot_test.go
+++ b/test/chroot_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/util"
+	. "github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/util"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/test/common_mem.go
+++ b/test/common_mem.go
@@ -3,14 +3,14 @@
 package test
 
 import (
-	"os"
+	"io/fs"
 
 	"github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/memfs"
 )
 
 var (
-	customMode            os.FileMode = 0o600
+	customMode            fs.FileMode = 0o600
 	expectedSymlinkTarget             = "/dir/file"
 )
 

--- a/test/common_mem.go
+++ b/test/common_mem.go
@@ -5,8 +5,8 @@ package test
 import (
 	"os"
 
-	"github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/memfs"
 )
 
 var (

--- a/test/common_posix.go
+++ b/test/common_posix.go
@@ -6,9 +6,9 @@ package test
 import (
 	"os"
 
-	"github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/memfs"
-	"github.com/go-git/go-billy/v5/osfs"
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/go-git/go-billy/v6/osfs"
 )
 
 var (

--- a/test/common_posix.go
+++ b/test/common_posix.go
@@ -4,7 +4,7 @@
 package test
 
 import (
-	"os"
+	"io/fs"
 
 	"github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/memfs"
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	customMode            os.FileMode = 0o755
+	customMode            fs.FileMode = 0o755
 	expectedSymlinkTarget             = "/dir/file"
 )
 

--- a/test/common_windows.go
+++ b/test/common_windows.go
@@ -6,9 +6,9 @@ package test
 import (
 	"os"
 
-	"github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/memfs"
-	"github.com/go-git/go-billy/v5/osfs"
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/go-git/go-billy/v6/osfs"
 )
 
 var (

--- a/test/common_windows.go
+++ b/test/common_windows.go
@@ -4,7 +4,7 @@
 package test
 
 import (
-	"os"
+	"io/fs"
 
 	"github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/memfs"
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	customMode            os.FileMode = 0o666
+	customMode            fs.FileMode = 0o666
 	expectedSymlinkTarget             = "\\dir\\file"
 )
 

--- a/test/dir_test.go
+++ b/test/dir_test.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"testing"
 
-	. "github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/util"
+	. "github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/util"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/test/fs_test.go
+++ b/test/fs_test.go
@@ -6,8 +6,8 @@ import (
 	"runtime"
 	"testing"
 
-	. "github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/util"
+	. "github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/util"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/test/symlink_test.go
+++ b/test/symlink_test.go
@@ -7,8 +7,8 @@ import (
 	"runtime"
 	"testing"
 
-	. "github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/util"
+	. "github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/util"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/test/tempfile_test.go
+++ b/test/tempfile_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/util"
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/util"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/util/glob.go
+++ b/util/glob.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 )
 
 // Glob returns the names of all files matching pattern or nil

--- a/util/glob_test.go
+++ b/util/glob_test.go
@@ -5,8 +5,8 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/go-git/go-billy/v5/memfs"
-	"github.com/go-git/go-billy/v5/util"
+	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/go-git/go-billy/v6/util"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/util/util.go
+++ b/util/util.go
@@ -3,6 +3,7 @@ package util
 import (
 	"errors"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -97,7 +98,7 @@ func removeAll(fs billy.Basic, path string) error {
 // WriteFile writes data to a file named by filename in the given filesystem.
 // If the file does not exist, WriteFile creates it with permissions perm;
 // otherwise WriteFile truncates it before writing.
-func WriteFile(fs billy.Basic, filename string, data []byte, perm os.FileMode) (err error) {
+func WriteFile(fs billy.Basic, filename string, data []byte, perm fs.FileMode) (err error) {
 	f, err := fs.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
 	if err != nil {
 		return err

--- a/util/util.go
+++ b/util/util.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 )
 
 // RemoveAll removes path and any children it contains. It removes everything it

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -6,8 +6,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/go-git/go-billy/v5/memfs"
-	"github.com/go-git/go-billy/v5/util"
+	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/go-git/go-billy/v6/util"
 )
 
 func TestTempFile(t *testing.T) {

--- a/util/walk.go
+++ b/util/walk.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 )
 
 // walk recursively descends path, calling walkFn
@@ -46,7 +46,7 @@ func walk(fs billy.Filesystem, path string, info os.FileInfo, walkFn filepath.Wa
 	return nil
 }
 
-// Walk walks the file tree rooted at root, calling fn for each file or 
+// Walk walks the file tree rooted at root, calling fn for each file or
 // directory in the tree, including root. All errors that arise visiting files
 // and directories are filtered by fn: see the WalkFunc documentation for
 // details.
@@ -54,7 +54,7 @@ func walk(fs billy.Filesystem, path string, info os.FileInfo, walkFn filepath.Wa
 // The files are walked in lexical order, which makes the output deterministic
 // but requires Walk to read an entire directory into memory before proceeding
 // to walk that directory. Walk does not follow symbolic links.
-// 
+//
 // Function adapted from https://github.com/golang/go/blob/3b770f2ccb1fa6fecc22ea822a19447b10b70c5c/src/path/filepath/path.go#L500
 func Walk(fs billy.Filesystem, root string, walkFn filepath.WalkFunc) error {
 	info, err := fs.Lstat(root)
@@ -63,10 +63,10 @@ func Walk(fs billy.Filesystem, root string, walkFn filepath.WalkFunc) error {
 	} else {
 		err = walk(fs, root, info, walkFn)
 	}
-	
+
 	if err == filepath.SkipDir {
 		return nil
 	}
-	
+
 	return err
 }

--- a/util/walk_test.go
+++ b/util/walk_test.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/memfs"
-	"github.com/go-git/go-billy/v5/util"
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/go-git/go-billy/v6/util"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
In preparation to the v6 release, bump the module so that consumers are not surprised by API changes when consuming
version from main. However, until the first v6 version is cut the API is subject to changes.

These changes also further align `go-billy` with upstream fs abstraction. But there is still plenty of room for alignment and improvement.

Relates to #101.