### PR TITLE
osfs: max out defaultDirectoryMode so umask applies correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ GOCMD = go
 GOTEST = $(GOCMD) test 
 WASIRUN_WRAPPER := $(CURDIR)/scripts/wasirun-wrapper
 
+# Coverage
+COVERAGE_REPORT := coverage.out
+COVERAGE_MODE := count
+
 GOLANGCI_VERSION ?= v1.64.5
 TOOLS_BIN := $(shell mkdir -p build/tools && realpath build/tools)
 

--- a/osfs/os.go
+++ b/osfs/os.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	defaultDirectoryMode = 0o755
+	defaultDirectoryMode = 0o777
 	defaultCreateMode    = 0o666
 )
 

--- a/osfs/os_bound_test.go
+++ b/osfs/os_bound_test.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/go-git/go-billy/v6"
@@ -1285,8 +1286,19 @@ func TestRename(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
+	umask := syscall.Umask(2)
 	err = fs.Rename(oldFile, newFile)
 	require.NoError(t, err)
+	syscall.Umask(umask)
+
+	di, err := os.Stat(filepath.Dir(filepath.Join(dir, newFile)))
+	require.NoError(t, err)
+	assert.NotNil(di)
+	expected := 0o775
+	actual := int(di.Mode().Perm())
+	assert.Equal(
+		expected, actual, "Permission mismatch - expected: 0o%o, actual: 0o%o", expected, actual,
+	)
 
 	fi, err := os.Stat(filepath.Join(dir, newFile))
 	require.NoError(t, err)

--- a/test/chroot_test.go
+++ b/test/chroot_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"fmt"
 	"os"
+	"syscall"
 	"testing"
 
 	. "github.com/go-git/go-billy/v6" //nolint
@@ -28,11 +29,21 @@ func eachChrootFS(t *testing.T, test func(t *testing.T, fs chrootFS)) {
 func TestCreateWithChroot(t *testing.T) {
 	eachChrootFS(t, func(t *testing.T, fs chrootFS) {
 		t.Helper()
+		umask := syscall.Umask(2)
 		chroot, _ := fs.Chroot("foo")
 		f, err := chroot.Create("bar")
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 		assert.Equal(t, f.Name(), "bar")
+		syscall.Umask(umask)
+
+		di, err := fs.Stat(fs.Join("foo"))
+		require.NoError(t, err)
+		expected := 0o775
+		actual := int(di.Mode().Perm())
+		assert.Equal(
+			t, expected, actual, "Permission mismatch - expected: 0o%o, actual: 0o%o", expected, actual,
+		)
 
 		f, err = fs.Open("foo/bar")
 		require.NoError(t, err)


### PR DESCRIPTION
a reprise of https://github.com/go-git/go-billy/pull/104, with added tests

The tests for `ChrootFS` do not work with a memfs backend, because memfs creates parent directories with bonkers permissions.

drive-by: add Makefile variables for `make test-coverage` to run successfully