### PR TITLE
osfs: add `file.Sync()` support

### DIFF
--- a/embedfs/embed.go
+++ b/embedfs/embed.go
@@ -236,6 +236,11 @@ func (f *file) Truncate(_ int64) error {
 	return billy.ErrReadOnly
 }
 
+// Sync for embedfs file is a no-op.
+func (f *file) Sync() error {
+	return nil
+}
+
 // Write is not supported.
 //
 // Calls will always return billy.ErrReadOnly.

--- a/fs.go
+++ b/fs.go
@@ -178,6 +178,8 @@ type File interface {
 	Unlock() error
 	// Truncate the file.
 	Truncate(size int64) error
+	// Commit the current contents of the file to stable storage.
+	Sync() error
 }
 
 // Capable interface can return the available features of a filesystem.

--- a/internal/test/mock.go
+++ b/internal/test/mock.go
@@ -140,6 +140,10 @@ func (*FileMock) Stat() (fs.FileInfo, error) {
 	return nil, nil
 }
 
+func (*FileMock) Sync() error {
+	return nil
+}
+
 func (*FileMock) Truncate(_ int64) error {
 	return nil
 }

--- a/memfs/file.go
+++ b/memfs/file.go
@@ -146,6 +146,11 @@ func (f *file) Unlock() error {
 	return nil
 }
 
+// Sync is a no-op in memfs.
+func (f *file) Sync() error {
+	return nil
+}
+
 type fileInfo struct {
 	name    string
 	size    int

--- a/util/util.go
+++ b/util/util.go
@@ -116,6 +116,10 @@ func WriteFile(fs billy.Basic, filename string, data []byte, perm fs.FileMode) (
 	if err == nil && n < len(data) {
 		err = io.ErrShortWrite
 	}
+	err = f.Sync()
+	if err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
Adds a call to `file.Sync()` to `util.WriteFile()` (right before closing the file, so it should be functionally equivalent) to ensure test coverage.

Fixes: Issue #86