### PR TITLE
osfs: Replace `filepath-securejoin` with `os.Root`

### DIFF
--- a/.github/workflows/bench-regression.yml
+++ b/.github/workflows/bench-regression.yml
@@ -52,6 +52,9 @@ jobs:
           go-version: stable
           cache-dependency-path: go.sum
 
+      - name: Download modules
+        run: go mod download
+
       - name: Run benchmarks
         id: bench
         run: go test -run='^$' -bench="$BENCH_FILTER" -benchmem -count=$BENCH_COUNT $BENCH_PATH > base.txt 2>&1
@@ -82,6 +85,9 @@ jobs:
         with:
           go-version: stable
           cache-dependency-path: go.sum
+
+      - name: Download modules
+        run: go mod download
 
       - name: Run benchmarks
         id: bench

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,8 @@
 module github.com/go-git/go-billy/v6
 
-// go-git supports the last 3 stable Go versions.
 go 1.25.0
 
 require (
-	github.com/cyphar/filepath-securejoin v0.6.1
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sys v0.43.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=
-github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/osfs/os.go
+++ b/osfs/os.go
@@ -22,62 +22,18 @@ const (
 var Default = &ChrootOS{}
 
 // New returns a new OS filesystem.
-// By default paths are deduplicated, but still enforced
-// under baseDir. For more info refer to WithDeduplicatePath.
 func New(baseDir string, opts ...Option) billy.Filesystem {
-	o := &options{
-		deduplicatePath: true,
-	}
+	o := &options{}
 	for _, opt := range opts {
 		opt(o)
 	}
 
 	if o.Type == BoundOSFS {
-		return newBoundOS(baseDir, o.deduplicatePath)
+		return newBoundOS(baseDir)
 	}
 
 	return newChrootOS(baseDir)
 }
-
-// WithBoundOS returns the option of using a Bound filesystem OS.
-func WithBoundOS() Option {
-	return func(o *options) {
-		o.Type = BoundOSFS
-	}
-}
-
-// WithChrootOS returns the option of using a Chroot filesystem OS.
-func WithChrootOS() Option {
-	return func(o *options) {
-		o.Type = ChrootOSFS
-	}
-}
-
-// WithDeduplicatePath toggles the deduplication of the base dir in the path.
-// This occurs when absolute links are being used.
-// Assuming base dir /base/dir and an absolute symlink /base/dir/target:
-//
-// With DeduplicatePath (default): /base/dir/target
-// Without DeduplicatePath: /base/dir/base/dir/target
-//
-// This option is only used by the BoundOS OS type.
-func WithDeduplicatePath(enabled bool) Option {
-	return func(o *options) {
-		o.deduplicatePath = enabled
-	}
-}
-
-type options struct {
-	Type
-	deduplicatePath bool
-}
-
-type Type int
-
-const (
-	ChrootOSFS Type = iota
-	BoundOSFS
-)
 
 func tempFile(dir, prefix string) (billy.File, error) {
 	f, err := os.CreateTemp(dir, prefix)

--- a/osfs/os_bench_test.go
+++ b/osfs/os_bench_test.go
@@ -17,12 +17,20 @@ import (
 
 const fileName = "foo.bar"
 
+func mustFromRoot(tb testing.TB, root *os.Root) billy.Filesystem {
+	tb.Helper()
+	fs, err := osfs.FromRoot(root)
+	require.NoError(tb, err)
+	return fs
+}
+
 type benchEnv struct {
 	baseDir string
 	root    *os.Root
 	mem     billy.Filesystem
 	chroot  billy.Filesystem
 	bound   billy.Filesystem
+	rootFS  billy.Filesystem
 }
 
 func newBenchEnv(b *testing.B, withFile bool) benchEnv {
@@ -32,6 +40,7 @@ func newBenchEnv(b *testing.B, withFile bool) benchEnv {
 	baseDir := b.TempDir()
 	root, err := os.OpenRoot(baseDir)
 	require.NoError(b, err)
+	b.Cleanup(func() { root.Close() })
 
 	m := memfs.New()
 	if withFile {
@@ -48,6 +57,7 @@ func newBenchEnv(b *testing.B, withFile bool) benchEnv {
 		mem:     m,
 		chroot:  osfs.New(baseDir, osfs.WithChrootOS()),
 		bound:   osfs.New(baseDir, osfs.WithBoundOS()),
+		rootFS:  mustFromRoot(b, root),
 	}
 }
 
@@ -56,12 +66,14 @@ func BenchmarkOpen(b *testing.B) {
 	b.Run("memfs", benchmarkOpen(e.mem))
 	b.Run("chrootOS", benchmarkOpen(e.chroot))
 	b.Run("boundOS", benchmarkOpen(e.bound))
+	b.Run("rootOS", benchmarkOpen(e.rootFS))
 	b.Run("go-lib", func(b *testing.B) {
 		for b.Loop() {
-			_, err := e.root.Open(fileName)
+			f, err := e.root.Open(fileName)
 			if err != nil {
 				b.Fatal("cannot open file", "error", err)
 			}
+			f.Close()
 		}
 	})
 }
@@ -71,6 +83,7 @@ func BenchmarkCreate(b *testing.B) {
 	b.Run("memfs", benchmarkCreate(e.mem))
 	b.Run("chrootOS", benchmarkCreate(e.chroot))
 	b.Run("boundOS", benchmarkCreate(e.bound))
+	b.Run("rootOS", benchmarkCreate(e.rootFS))
 	b.Run("go-lib", func(b *testing.B) {
 		for b.Loop() {
 			f, err := e.root.Create(fileName)
@@ -87,6 +100,7 @@ func BenchmarkStat(b *testing.B) {
 	b.Run("memfs", benchmarkStat(e.mem))
 	b.Run("chrootOS", benchmarkStat(e.chroot))
 	b.Run("boundOS", benchmarkStat(e.bound))
+	b.Run("rootOS", benchmarkStat(e.rootFS))
 	b.Run("go-lib", func(b *testing.B) {
 		for b.Loop() {
 			_, err := e.root.Stat(fileName)
@@ -102,6 +116,7 @@ func BenchmarkLstat(b *testing.B) {
 	b.Run("memfs", benchmarkLstat(e.mem))
 	b.Run("chrootOS", benchmarkLstat(e.chroot))
 	b.Run("boundOS", benchmarkLstat(e.bound))
+	b.Run("rootOS", benchmarkLstat(e.rootFS))
 	b.Run("go-lib", func(b *testing.B) {
 		for b.Loop() {
 			_, err := e.root.Lstat(fileName)
@@ -119,6 +134,7 @@ func newBenchEnvMany(b *testing.B, n int) benchEnv {
 	baseDir := b.TempDir()
 	root, err := os.OpenRoot(baseDir)
 	require.NoError(b, err)
+	b.Cleanup(func() { root.Close() })
 
 	osfn := filepath.Join(baseDir, fileName)
 	m := memfs.New()
@@ -136,6 +152,7 @@ func newBenchEnvMany(b *testing.B, n int) benchEnv {
 		mem:     m,
 		chroot:  osfs.New(baseDir, osfs.WithChrootOS()),
 		bound:   osfs.New(baseDir, osfs.WithBoundOS()),
+		rootFS:  mustFromRoot(b, root),
 	}
 }
 
@@ -144,6 +161,7 @@ func BenchmarkReaddir(b *testing.B) {
 	b.Run("memfs", benchmarkReaddir(e.mem, "."))
 	b.Run("chrootOS", benchmarkReaddir(e.chroot, "."))
 	b.Run("boundOS", benchmarkReaddir(e.bound, "."))
+	b.Run("rootOS", benchmarkReaddir(e.rootFS, "."))
 	b.Run("go-lib", func(b *testing.B) {
 		for b.Loop() {
 			_, err := os.ReadDir(e.baseDir)
@@ -159,6 +177,7 @@ func BenchmarkWalkdir(b *testing.B) {
 	b.Run("memfs", benchmarkWalkdir(iofs.New(e.mem)))
 	b.Run("chrootOS", benchmarkWalkdir(iofs.New(e.chroot)))
 	b.Run("boundOS", benchmarkWalkdir(iofs.New(e.bound)))
+	b.Run("rootOS", benchmarkWalkdir(iofs.New(e.rootFS)))
 	b.Run("go-lib", benchmarkWalkdir(e.root.FS()))
 }
 
@@ -167,9 +186,11 @@ func BenchmarkRename(b *testing.B) {
 	b.Run("memfs", benchmarkRename(e.mem))
 	b.Run("chrootOS", benchmarkRename(e.chroot))
 	b.Run("boundOS", benchmarkRename(e.bound))
+	b.Run("rootOS", benchmarkRename(e.rootFS))
 	b.Run("go-lib", func(b *testing.B) {
 		for b.Loop() {
 			b.StopTimer()
+			_ = e.root.Remove("rename-dst")
 			f, err := e.root.Create("rename-src")
 			if err != nil {
 				b.Fatal(err)
@@ -190,6 +211,7 @@ func BenchmarkRemove(b *testing.B) {
 	b.Run("memfs", benchmarkRemove(e.mem))
 	b.Run("chrootOS", benchmarkRemove(e.chroot))
 	b.Run("boundOS", benchmarkRemove(e.bound))
+	b.Run("rootOS", benchmarkRemove(e.rootFS))
 	b.Run("go-lib", func(b *testing.B) {
 		for b.Loop() {
 			b.StopTimer()
@@ -211,10 +233,11 @@ func BenchmarkRemove(b *testing.B) {
 func benchmarkOpen(fs billy.Filesystem) func(b *testing.B) {
 	return func(b *testing.B) {
 		for b.Loop() {
-			_, err := fs.Open(fileName)
+			f, err := fs.Open(fileName)
 			if err != nil {
 				b.Fatal("cannot open file", "error", err)
 			}
+			f.Close()
 		}
 	}
 }
@@ -289,6 +312,7 @@ func benchmarkRename(fs billy.Filesystem) func(b *testing.B) {
 	return func(b *testing.B) {
 		for b.Loop() {
 			b.StopTimer()
+			_ = fs.Remove("rename-dst")
 			f, err := fs.Create("rename-src")
 			if err != nil {
 				b.Fatal(err)

--- a/osfs/os_bench_test.go
+++ b/osfs/os_bench_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/helper/iofs"
 	"github.com/go-git/go-billy/v6/memfs"
 	"github.com/go-git/go-billy/v6/osfs"
 	"github.com/go-git/go-billy/v6/util"
@@ -16,28 +17,48 @@ import (
 
 const fileName = "foo.bar"
 
-func BenchmarkOpen(b *testing.B) {
+type benchEnv struct {
+	baseDir string
+	root    *os.Root
+	mem     billy.Filesystem
+	chroot  billy.Filesystem
+	bound   billy.Filesystem
+}
+
+func newBenchEnv(b *testing.B, withFile bool) benchEnv {
+	b.Helper()
 	b.StopTimer()
+
 	baseDir := b.TempDir()
 	root, err := os.OpenRoot(baseDir)
 	require.NoError(b, err)
 
-	osfn := filepath.Join(baseDir, fileName)
-
-	err = os.WriteFile(osfn, []byte("test"), 0o600)
-	require.NoError(b, err)
-
 	m := memfs.New()
-	err = util.WriteFile(m, fileName, []byte("test"), 0o600)
-	require.NoError(b, err)
-	b.StartTimer()
+	if withFile {
+		err = os.WriteFile(filepath.Join(baseDir, fileName), []byte("test"), 0o600)
+		require.NoError(b, err)
+		err = util.WriteFile(m, fileName, []byte("test"), 0o600)
+		require.NoError(b, err)
+	}
 
-	b.Run("memfs", benchmarkOpen(m))
-	b.Run("chrootOS", benchmarkOpen(osfs.New(baseDir, osfs.WithChrootOS())))
-	b.Run("boundOS", benchmarkOpen(osfs.New(baseDir, osfs.WithBoundOS())))
+	b.StartTimer()
+	return benchEnv{
+		baseDir: baseDir,
+		root:    root,
+		mem:     m,
+		chroot:  osfs.New(baseDir, osfs.WithChrootOS()),
+		bound:   osfs.New(baseDir, osfs.WithBoundOS()),
+	}
+}
+
+func BenchmarkOpen(b *testing.B) {
+	e := newBenchEnv(b, true)
+	b.Run("memfs", benchmarkOpen(e.mem))
+	b.Run("chrootOS", benchmarkOpen(e.chroot))
+	b.Run("boundOS", benchmarkOpen(e.bound))
 	b.Run("go-lib", func(b *testing.B) {
 		for b.Loop() {
-			_, err := root.Open(fileName)
+			_, err := e.root.Open(fileName)
 			if err != nil {
 				b.Fatal("cannot open file", "error", err)
 			}
@@ -45,27 +66,87 @@ func BenchmarkOpen(b *testing.B) {
 	})
 }
 
-func BenchmarkReaddir(b *testing.B) {
+func BenchmarkCreate(b *testing.B) {
+	e := newBenchEnv(b, false)
+	b.Run("memfs", benchmarkCreate(e.mem))
+	b.Run("chrootOS", benchmarkCreate(e.chroot))
+	b.Run("boundOS", benchmarkCreate(e.bound))
+	b.Run("go-lib", func(b *testing.B) {
+		for b.Loop() {
+			f, err := e.root.Create(fileName)
+			if err != nil {
+				b.Fatal("cannot create file", "error", err)
+			}
+			f.Close()
+		}
+	})
+}
+
+func BenchmarkStat(b *testing.B) {
+	e := newBenchEnv(b, true)
+	b.Run("memfs", benchmarkStat(e.mem))
+	b.Run("chrootOS", benchmarkStat(e.chroot))
+	b.Run("boundOS", benchmarkStat(e.bound))
+	b.Run("go-lib", func(b *testing.B) {
+		for b.Loop() {
+			_, err := e.root.Stat(fileName)
+			if err != nil {
+				b.Fatal("cannot stat file", "error", err)
+			}
+		}
+	})
+}
+
+func BenchmarkLstat(b *testing.B) {
+	e := newBenchEnv(b, true)
+	b.Run("memfs", benchmarkLstat(e.mem))
+	b.Run("chrootOS", benchmarkLstat(e.chroot))
+	b.Run("boundOS", benchmarkLstat(e.bound))
+	b.Run("go-lib", func(b *testing.B) {
+		for b.Loop() {
+			_, err := e.root.Lstat(fileName)
+			if err != nil {
+				b.Fatal("cannot lstat file", "error", err)
+			}
+		}
+	})
+}
+
+func newBenchEnvMany(b *testing.B, n int) benchEnv {
+	b.Helper()
 	b.StopTimer()
+
 	baseDir := b.TempDir()
+	root, err := os.OpenRoot(baseDir)
+	require.NoError(b, err)
+
 	osfn := filepath.Join(baseDir, fileName)
-
 	m := memfs.New()
-	for i := 0; i < 1000; i++ {
-		err := os.WriteFile(fmt.Sprint(osfn, i), []byte("test"), 0o600)
+	for i := range n {
+		err = os.WriteFile(fmt.Sprint(osfn, i), []byte("test"), 0o600)
 		require.NoError(b, err)
-
 		err = util.WriteFile(m, fmt.Sprint(fileName, i), []byte("test"), 0o600)
 		require.NoError(b, err)
 	}
-	b.StartTimer()
 
-	b.Run("memfs", benchmarkReaddir(m, "."))
-	b.Run("chrootOS", benchmarkReaddir(osfs.New(baseDir, osfs.WithChrootOS()), "."))
-	b.Run("boundOS", benchmarkReaddir(osfs.New(baseDir, osfs.WithBoundOS()), "."))
+	b.StartTimer()
+	return benchEnv{
+		baseDir: baseDir,
+		root:    root,
+		mem:     m,
+		chroot:  osfs.New(baseDir, osfs.WithChrootOS()),
+		bound:   osfs.New(baseDir, osfs.WithBoundOS()),
+	}
+}
+
+func BenchmarkReaddir(b *testing.B) {
+	e := newBenchEnvMany(b, 1000)
+	b.Run("memfs", benchmarkReaddir(e.mem, "."))
+	b.Run("chrootOS", benchmarkReaddir(e.chroot, "."))
+	b.Run("boundOS", benchmarkReaddir(e.bound, "."))
 	b.Run("go-lib", func(b *testing.B) {
 		for b.Loop() {
-			_, err := os.ReadDir(baseDir)
+			_, err := os.ReadDir(e.baseDir)
 			if err != nil {
 				b.Fatal("cannot read dir", "error", err)
 			}
@@ -74,38 +155,54 @@ func BenchmarkReaddir(b *testing.B) {
 }
 
 func BenchmarkWalkdir(b *testing.B) {
-	b.StopTimer()
-	baseDir := b.TempDir()
-	root, err := os.OpenRoot(baseDir)
-	require.NoError(b, err)
-	osfn := filepath.Join(baseDir, fileName)
+	e := newBenchEnvMany(b, 1000)
+	b.Run("memfs", benchmarkWalkdir(iofs.New(e.mem)))
+	b.Run("chrootOS", benchmarkWalkdir(iofs.New(e.chroot)))
+	b.Run("boundOS", benchmarkWalkdir(iofs.New(e.bound)))
+	b.Run("go-lib", benchmarkWalkdir(e.root.FS()))
+}
 
-	m := memfs.New()
-	for i := 0; i < 1000; i++ {
-		err = os.WriteFile(fmt.Sprint(osfn, i), []byte("test"), 0o600)
-		require.NoError(b, err)
-
-		err = util.WriteFile(m, fmt.Sprint(fileName, i), []byte("test"), 0o600)
-		require.NoError(b, err)
-	}
-	b.StartTimer()
-
-	b.Run("memfs", benchmarkReaddir(m, "."))
-	b.Run("chrootOS", benchmarkReaddir(osfs.New(baseDir, osfs.WithChrootOS()), "."))
-	b.Run("boundOS", benchmarkReaddir(osfs.New(baseDir, osfs.WithBoundOS()), "."))
+func BenchmarkRename(b *testing.B) {
+	e := newBenchEnv(b, false)
+	b.Run("memfs", benchmarkRename(e.mem))
+	b.Run("chrootOS", benchmarkRename(e.chroot))
+	b.Run("boundOS", benchmarkRename(e.bound))
 	b.Run("go-lib", func(b *testing.B) {
 		for b.Loop() {
-			i := 0
-			err := fs.WalkDir(root.FS(), ".", func(_ string, _ fs.DirEntry, err error) error {
-				i++
-				return err
-			})
+			b.StopTimer()
+			f, err := e.root.Create("rename-src")
 			if err != nil {
-				b.Fatal("cannot walk dir", "error", err)
+				b.Fatal(err)
 			}
+			f.Close()
+			b.StartTimer()
 
-			if i != 1001 { // 1000 files + dir entry
-				b.Fatal("wrong walk number", "i", i)
+			err = e.root.Rename("rename-src", "rename-dst")
+			if err != nil {
+				b.Fatal("cannot rename file", "error", err)
+			}
+		}
+	})
+}
+
+func BenchmarkRemove(b *testing.B) {
+	e := newBenchEnv(b, false)
+	b.Run("memfs", benchmarkRemove(e.mem))
+	b.Run("chrootOS", benchmarkRemove(e.chroot))
+	b.Run("boundOS", benchmarkRemove(e.bound))
+	b.Run("go-lib", func(b *testing.B) {
+		for b.Loop() {
+			b.StopTimer()
+			f, err := e.root.Create("remove-target")
+			if err != nil {
+				b.Fatal(err)
+			}
+			f.Close()
+			b.StartTimer()
+
+			err = e.root.Remove("remove-target")
+			if err != nil {
+				b.Fatal("cannot remove file", "error", err)
 			}
 		}
 	})
@@ -122,6 +219,58 @@ func benchmarkOpen(fs billy.Filesystem) func(b *testing.B) {
 	}
 }
 
+func benchmarkCreate(fs billy.Filesystem) func(b *testing.B) {
+	return func(b *testing.B) {
+		for b.Loop() {
+			f, err := fs.Create(fileName)
+			if err != nil {
+				b.Fatal("cannot create file", "error", err)
+			}
+			f.Close()
+		}
+	}
+}
+
+func benchmarkStat(fs billy.Filesystem) func(b *testing.B) {
+	return func(b *testing.B) {
+		for b.Loop() {
+			_, err := fs.Stat(fileName)
+			if err != nil {
+				b.Fatal("cannot stat file", "error", err)
+			}
+		}
+	}
+}
+
+func benchmarkLstat(fs billy.Filesystem) func(b *testing.B) {
+	return func(b *testing.B) {
+		for b.Loop() {
+			_, err := fs.Lstat(fileName)
+			if err != nil {
+				b.Fatal("cannot lstat file", "error", err)
+			}
+		}
+	}
+}
+
+func benchmarkWalkdir(fsys fs.FS) func(b *testing.B) {
+	return func(b *testing.B) {
+		for b.Loop() {
+			i := 0
+			err := fs.WalkDir(fsys, ".", func(_ string, _ fs.DirEntry, err error) error {
+				i++
+				return err
+			})
+			if err != nil {
+				b.Fatal("cannot walk dir", "error", err)
+			}
+			if i != 1001 { // 1000 files + dir entry
+				b.Fatal("wrong walk number", "i", i)
+			}
+		}
+	}
+}
+
 func benchmarkReaddir(fs billy.Filesystem, path string) func(b *testing.B) {
 	return func(b *testing.B) {
 		for b.Loop() {
@@ -131,6 +280,44 @@ func benchmarkReaddir(fs billy.Filesystem, path string) func(b *testing.B) {
 			}
 			if len(fi) != 1000 {
 				b.Fatal("missing files", "len", len(fi))
+			}
+		}
+	}
+}
+
+func benchmarkRename(fs billy.Filesystem) func(b *testing.B) {
+	return func(b *testing.B) {
+		for b.Loop() {
+			b.StopTimer()
+			f, err := fs.Create("rename-src")
+			if err != nil {
+				b.Fatal(err)
+			}
+			f.Close()
+			b.StartTimer()
+
+			err = fs.Rename("rename-src", "rename-dst")
+			if err != nil {
+				b.Fatal("cannot rename file", "error", err)
+			}
+		}
+	}
+}
+
+func benchmarkRemove(fs billy.Filesystem) func(b *testing.B) {
+	return func(b *testing.B) {
+		for b.Loop() {
+			b.StopTimer()
+			f, err := fs.Create("remove-target")
+			if err != nil {
+				b.Fatal(err)
+			}
+			f.Close()
+			b.StartTimer()
+
+			err = fs.Remove("remove-target")
+			if err != nil {
+				b.Fatal("cannot remove file", "error", err)
 			}
 		}
 	}

--- a/osfs/os_bound.go
+++ b/osfs/os_bound.go
@@ -19,64 +19,138 @@
 package osfs
 
 import (
+	"errors"
 	"fmt"
-	"io/fs"
+	gofs "io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 
-	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/util"
 )
 
-var dotPrefixes = []string{"./", ".\\"}
+// ErrPathEscapesParent represents when an action leads to escaping from the
+// given dir the filesystem is bound to.
+//
+// The upstream version of this error used by [os.Root] is not public.
+var ErrPathEscapesParent = errors.New("path escapes from parent")
 
-// BoundOS is a fs implementation based on the OS filesystem which is bound to
-// a base dir.
-// Prefer this fs implementation over ChrootOS.
+// FromRoot creates a new instance of BoundOS from an [os.Root].
+// The base dir is set to root.Name(). Unlike [New] with [WithBoundOS],
+// the provided root is used directly for all operations rather than
+// opening a fresh [os.Root] per operation; the caller is responsible
+// for the root's lifecycle. If root is nil, all filesystem operations
+// will fail with an error.
+func FromRoot(root *os.Root) billy.Filesystem {
+	if root == nil {
+		return &BoundOS{rootError: errors.New("root is nil")}
+	}
+	return &BoundOS{baseDir: root.Name(), root: root}
+}
+
+// BoundOS is a fs implementation based on the OS filesystem which relies on
+// Go's os.Root. Prefer this fs implementation over ChrootOS.
+//
+// When created via [New] with [WithBoundOS], a new [os.Root] is opened and
+// closed for each filesystem operation. When created via [FromRoot], the
+// provided [os.Root] is used directly for all operations and the caller is
+// responsible for its lifecycle.
 //
 // Behaviours of note:
 //  1. Read and write operations can only be directed to files which descends
 //     from the base dir.
 //  2. Symlinks don't have their targets modified, and therefore can point
 //     to locations outside the base dir or to non-existent paths.
-//  3. Readlink and Lstat ensures that the link file is located within the base
-//     dir, evaluating any symlinks that file or base dir may contain.
+//  3. Operations leading to escapes to outside the [os.Root] location results
+//     in [ErrPathEscapesParent].
 type BoundOS struct {
-	baseDir         string
-	deduplicatePath bool
+	baseDir   string
+	root      *os.Root // non-nil only for FromRoot; newBoundOS opens per-op
+	rootError error
 }
 
-func newBoundOS(d string, deduplicatePath bool) billy.Filesystem {
-	return &BoundOS{baseDir: d, deduplicatePath: deduplicatePath}
+func newBoundOS(d string) billy.Filesystem {
+	return &BoundOS{baseDir: d}
 }
 
 func (fs *BoundOS) Capabilities() billy.Capability {
 	return billy.DefaultCapabilities & billy.SyncCapability
 }
 
-func (fs *BoundOS) Create(filename string) (billy.File, error) {
-	return fs.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, defaultCreateMode)
+func (fs *BoundOS) Create(name string) (billy.File, error) {
+	return fs.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, defaultCreateMode)
 }
 
-func (fs *BoundOS) OpenFile(filename string, flag int, perm fs.FileMode) (billy.File, error) {
-	filename = fs.expandDot(filename)
-	fn, err := fs.abs(filename)
+func (fs *BoundOS) OpenFile(name string, flag int, perm gofs.FileMode) (billy.File, error) {
+	root, cleanup, err := fs.fsRoot()
 	if err != nil {
 		return nil, err
 	}
+	defer cleanup()
 
-	return openFile(fn, flag, perm, fs.createDir)
-}
+	// When not creating, read symlink links so that they can be made
+	// relative and therefore work.
+	if flag&os.O_CREATE == 0 {
+		fi, err := root.Lstat(name)
+		if err == nil && fi.Mode()&gofs.ModeSymlink != 0 {
+			fn, err := root.Readlink(name)
+			if err != nil {
+				return nil, err
+			}
+			name = fn
+		}
+	}
 
-func (fs *BoundOS) ReadDir(path string) ([]fs.DirEntry, error) {
-	path = fs.expandDot(path)
-	dir, err := fs.abs(path)
+	if filepath.IsAbs(name) {
+		fn, err := filepath.Rel(fs.baseDir, name)
+		if err != nil {
+			return nil, err
+		}
+		name = fn
+	}
+
+	if flag&os.O_CREATE != 0 {
+		if err = fs.createDir(root, name); err != nil {
+			return nil, translateError(err, name)
+		}
+	}
+
+	f, err := root.OpenFile(name, flag, perm)
 	if err != nil {
 		return nil, err
 	}
+	return &file{File: f}, nil
+}
 
-	return os.ReadDir(dir)
+func (fs *BoundOS) ReadDir(name string) ([]gofs.DirEntry, error) {
+	if filepath.IsAbs(name) {
+		fn, err := filepath.Rel(fs.baseDir, name)
+		if err != nil {
+			return nil, err
+		}
+		name = fn
+	}
+
+	if name == "" {
+		name = "."
+	}
+
+	root, cleanup, err := fs.fsRoot()
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	f, err := root.Open(name)
+	if err != nil {
+		return nil, translateError(err, name)
+	}
+
+	e, err := f.ReadDir(-1)
+	if err != nil {
+		return nil, translateError(err, name)
+	}
+	return e, nil
 }
 
 func (fs *BoundOS) Rename(from, to string) error {
@@ -84,169 +158,232 @@ func (fs *BoundOS) Rename(from, to string) error {
 		return billy.ErrBaseDirCannotBeRenamed
 	}
 
-	from = fs.expandDot(from)
-	_, err := fs.Lstat(from)
+	root, cleanup, err := fs.fsRoot()
 	if err != nil {
 		return err
 	}
+	defer cleanup()
 
-	f, err := fs.abs(from)
-	if err != nil {
-		return err
+	// Ensure the target directory exists.
+	err = root.MkdirAll(filepath.Dir(to), defaultDirectoryMode)
+	if err == nil {
+		err = root.Rename(from, to)
 	}
 
-	to = fs.expandDot(to)
-	t, err := fs.abs(to)
-	if err != nil {
-		return err
-	}
-
-	// MkdirAll for target name.
-	if err := fs.createDir(t); err != nil {
-		return err
-	}
-
-	return os.Rename(f, t)
+	return translateError(err, to)
 }
 
-func (fs *BoundOS) MkdirAll(path string, perm fs.FileMode) error {
-	path = fs.expandDot(path)
-	dir, err := fs.abs(path)
+func (fs *BoundOS) MkdirAll(name string, _ gofs.FileMode) error {
+	root, cleanup, err := fs.fsRoot()
 	if err != nil {
 		return err
 	}
-	return os.MkdirAll(dir, perm)
+	defer cleanup()
+
+	// os.Root errors when perm contains bits other than the nine least-significant bits (0o777).
+	err = root.MkdirAll(name, 0o777)
+	return translateError(err, name)
 }
 
-func (fs *BoundOS) Open(filename string) (billy.File, error) {
-	return fs.OpenFile(filename, os.O_RDONLY, 0)
+func (fs *BoundOS) Open(name string) (billy.File, error) {
+	return fs.OpenFile(name, os.O_RDONLY, 0)
 }
 
-func (fs *BoundOS) Stat(filename string) (os.FileInfo, error) {
-	filename = fs.expandDot(filename)
-	filename, err := fs.abs(filename)
-	if err != nil {
-		return nil, err
-	}
-	return os.Stat(filename)
-}
-
-func (fs *BoundOS) Remove(filename string) error {
-	if filename == "." || filename == fs.baseDir {
-		return billy.ErrBaseDirCannotBeRemoved
-	}
-
-	fn, err := fs.abs(filename)
-	if err != nil {
-		return err
-	}
-	return os.Remove(fn)
-}
-
-// TempFile creates a temporary file. If dir is empty, the file
-// will be created within the OS Temporary dir. If dir is provided
-// it must descend from the current base dir.
-func (fs *BoundOS) TempFile(dir, prefix string) (billy.File, error) {
-	if dir != "" {
-		var err error
-		dir, err = fs.abs(dir)
+func (fs *BoundOS) Stat(name string) (os.FileInfo, error) {
+	if filepath.IsAbs(name) {
+		fn, err := filepath.Rel(fs.baseDir, name)
 		if err != nil {
 			return nil, err
 		}
 
-		_, err = os.Stat(dir)
+		_, err = os.Stat(fs.baseDir)
 		if err != nil && os.IsNotExist(err) {
-			err = os.MkdirAll(dir, defaultDirectoryMode)
+			err = os.MkdirAll(fs.baseDir, defaultDirectoryMode)
 			if err != nil {
 				return nil, err
 			}
 		}
+		name = fn
 	}
 
-	return tempFile(dir, prefix)
+	if name == "" {
+		name = "."
+	}
+
+	root, cleanup, err := fs.fsRoot()
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	fi, err := root.Stat(name)
+	if err != nil {
+		return nil, translateError(err, name)
+	}
+
+	return fi, nil
+}
+
+func (fs *BoundOS) Remove(name string) error {
+	if name == "." || name == fs.baseDir {
+		return billy.ErrBaseDirCannotBeRemoved
+	}
+
+	if filepath.IsAbs(name) {
+		fn, err := filepath.Rel(fs.baseDir, name)
+		if err != nil {
+			return err
+		}
+		name = fn
+	}
+
+	root, cleanup, err := fs.fsRoot()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	err = root.Remove(name)
+	if err == nil {
+		return nil
+	}
+
+	return translateError(err, name)
+}
+
+// TempFile creates a temporary file. If dir is empty, the file
+// will be created within a .tmp dir.
+//
+// If dir is outside the bound dir, [ErrPathEscapesParent] is returned.
+func (fs *BoundOS) TempFile(dir, prefix string) (billy.File, error) {
+	return util.TempFile(fs, dir, prefix)
 }
 
 func (fs *BoundOS) Join(elem ...string) string {
 	return filepath.Join(elem...)
 }
 
-func (fs *BoundOS) RemoveAll(path string) error {
-	if path == "." || path == fs.baseDir {
+func (fs *BoundOS) RemoveAll(name string) error {
+	if name == "." || name == fs.baseDir {
 		return billy.ErrBaseDirCannotBeRemoved
 	}
 
-	path = fs.expandDot(path)
-	dir, err := fs.abs(path)
-	if err != nil {
-		return err
-	}
-	return os.RemoveAll(dir)
-}
-
-func (fs *BoundOS) Symlink(target, link string) error {
-	link = fs.expandDot(link)
-	ln, err := fs.abs(link)
-	if err != nil {
-		return err
-	}
-	// MkdirAll for containing dir.
-	if err := fs.createDir(ln); err != nil {
-		return err
-	}
-	return os.Symlink(target, ln)
-}
-
-func (fs *BoundOS) expandDot(p string) string {
-	if p == "." {
-		return fs.baseDir
-	}
-	for _, prefix := range dotPrefixes {
-		if strings.HasPrefix(p, prefix) {
-			return filepath.Join(fs.baseDir, strings.TrimPrefix(p, prefix))
+	if filepath.IsAbs(name) {
+		fn, err := filepath.Rel(fs.baseDir, name)
+		if err != nil {
+			return err
 		}
+		name = fn
 	}
-	return p
+
+	root, cleanup, err := fs.fsRoot()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	return root.RemoveAll(name)
 }
 
-func (fs *BoundOS) Lstat(filename string) (os.FileInfo, error) {
-	filename = fs.expandDot(filename)
-	filename = filepath.Clean(filename)
-	if !filepath.IsAbs(filename) {
-		filename = filepath.Join(fs.baseDir, filename)
+func (fs *BoundOS) Symlink(oldname, newname string) error {
+	if filepath.IsAbs(newname) {
+		fn, err := filepath.Rel(fs.baseDir, newname)
+		if err != nil {
+			return err
+		}
+		newname = fn
 	}
-	if ok, err := fs.insideBaseDirEval(filename); !ok {
+
+	root, cleanup, err := fs.fsRoot()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	err = fs.createDir(root, newname)
+	if err != nil {
+		return err
+	}
+
+	return root.Symlink(oldname, newname)
+}
+
+func (fs *BoundOS) Lstat(name string) (os.FileInfo, error) {
+	if filepath.IsAbs(name) {
+		fn, err := filepath.Rel(fs.baseDir, name)
+		if err != nil {
+			return nil, err
+		}
+		name = fn
+	}
+
+	root, cleanup, err := fs.fsRoot()
+	if err != nil {
 		return nil, err
 	}
-	return os.Lstat(filename)
+	defer cleanup()
+
+	fi, err := root.Lstat(name)
+	if err != nil {
+		return nil, translateError(err, name)
+	}
+
+	return fi, nil
 }
 
-func (fs *BoundOS) Readlink(link string) (string, error) {
-	link = fs.expandDot(link)
-	if !filepath.IsAbs(link) {
-		link = filepath.Clean(filepath.Join(fs.baseDir, link))
-	}
-	if ok, err := fs.insideBaseDirEval(link); !ok {
+func (fs *BoundOS) Readlink(name string) (string, error) {
+	root, cleanup, err := fs.fsRoot()
+	if err != nil {
 		return "", err
 	}
-	return os.Readlink(link)
+	defer cleanup()
+
+	lnk, err := root.Readlink(name)
+	if err != nil {
+		return "", translateError(err, name)
+	}
+
+	return lnk, nil
 }
 
-func (fs *BoundOS) Chmod(path string, mode fs.FileMode) error {
-	abspath, err := fs.abs(path)
+func (fs *BoundOS) Chmod(path string, mode gofs.FileMode) error {
+	root, cleanup, err := fs.fsRoot()
 	if err != nil {
 		return err
 	}
-	return os.Chmod(abspath, mode)
+	defer cleanup()
+	return root.Chmod(path, mode)
 }
 
 // Chroot returns a new BoundOS filesystem, with the base dir set to the
 // result of joining the provided path with the underlying base dir.
 func (fs *BoundOS) Chroot(path string) (billy.Filesystem, error) {
-	joined, err := securejoin.SecureJoin(fs.baseDir, path)
+	root, cleanup, err := fs.fsRoot()
 	if err != nil {
 		return nil, err
 	}
-	return New(joined, WithBoundOS()), nil
+	defer cleanup()
+
+	fi, err := root.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		err := root.MkdirAll(path, defaultDirectoryMode)
+		if err != nil {
+			return nil, fmt.Errorf("failed to auto create dir: %w", err)
+		}
+	} else if err != nil {
+		return nil, err
+	}
+	if fi != nil && !fi.IsDir() {
+		return nil, fmt.Errorf("cannot chroot: path is not dir")
+	}
+
+	childRoot, err := root.OpenRoot(path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to chroot: %w", err)
+	}
+	defer childRoot.Close()
+
+	return New(childRoot.Name(), WithBoundOS()), nil
 }
 
 // Root returns the current base dir of the billy.Filesystem.
@@ -256,10 +393,10 @@ func (fs *BoundOS) Root() string {
 	return fs.baseDir
 }
 
-func (fs *BoundOS) createDir(fullpath string) error {
+func (fs *BoundOS) createDir(root *os.Root, fullpath string) error {
 	dir := filepath.Dir(fullpath)
 	if dir != "." {
-		if err := os.MkdirAll(dir, defaultDirectoryMode); err != nil {
+		if err := root.MkdirAll(dir, defaultDirectoryMode); err != nil {
 			return err
 		}
 	}
@@ -267,49 +404,33 @@ func (fs *BoundOS) createDir(fullpath string) error {
 	return nil
 }
 
-// abs transforms filename to an absolute path, taking into account the base dir.
-// Relative paths won't be allowed to ascend the base dir, so `../file` will become
-// `/working-dir/file`.
-//
-// Note that if filename is a symlink, the returned address will be the target of the
-// symlink.
-func (fs *BoundOS) abs(filename string) (string, error) {
-	if filename == fs.baseDir {
-		filename = string(filepath.Separator)
+// fsRoot returns the [os.Root] to use for filesystem operations along with
+// a cleanup function that must be called when the root is no longer needed.
+// For BoundOS instances created via [FromRoot], the cleanup is a no-op and
+// the caller-provided root is returned directly. Otherwise, a new [os.Root]
+// is opened for each call and closed by the cleanup function.
+func (fs *BoundOS) fsRoot() (*os.Root, func(), error) {
+	if fs.rootError != nil {
+		return nil, func() {}, fs.rootError
 	}
-
-	path, err := securejoin.SecureJoin(fs.baseDir, filename)
+	if fs.root != nil {
+		return fs.root, func() {}, nil
+	}
+	r, err := os.OpenRoot(fs.baseDir)
 	if err != nil {
-		return "", err
+		return nil, func() {}, err
 	}
-
-	if fs.deduplicatePath {
-		vol := filepath.VolumeName(fs.baseDir)
-		dup := filepath.Join(fs.baseDir, fs.baseDir[len(vol):])
-		if strings.HasPrefix(path, dup+string(filepath.Separator)) {
-			return fs.abs(path[len(dup):])
-		}
-	}
-	return path, nil
+	return r, func() { r.Close() }, nil
 }
 
-// insideBaseDirEval checks whether filename is contained within
-// a dir that is within the fs.baseDir, by first evaluating any symlinks
-// that either filename or fs.baseDir may contain.
-func (fs *BoundOS) insideBaseDirEval(filename string) (bool, error) {
-	if fs.baseDir == "/" || fs.baseDir == "" || fs.baseDir == filename {
-		return true, nil
+func translateError(err error, file string) error {
+	if err == nil {
+		return nil
 	}
-	dir, err := filepath.EvalSymlinks(filepath.Dir(filename))
-	if dir == "" || os.IsNotExist(err) {
-		dir = filepath.Dir(filename)
+
+	if errors.Unwrap(err).Error() == ErrPathEscapesParent.Error() {
+		return fmt.Errorf("%w: %q", ErrPathEscapesParent, file)
 	}
-	wd, err := filepath.EvalSymlinks(fs.baseDir)
-	if wd == "" || os.IsNotExist(err) {
-		wd = fs.baseDir
-	}
-	if filename != wd && dir != wd && !strings.HasPrefix(dir, wd+string(filepath.Separator)) {
-		return false, fmt.Errorf("%q: path outside base dir %q: %w", filename, fs.baseDir, os.ErrNotExist)
-	}
-	return true, nil
+
+	return err
 }

--- a/osfs/os_bound.go
+++ b/osfs/os_bound.go
@@ -24,6 +24,7 @@ import (
 	gofs "io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/util"
@@ -74,7 +75,7 @@ func newBoundOS(d string) billy.Filesystem {
 }
 
 func (fs *BoundOS) Capabilities() billy.Capability {
-	return billy.DefaultCapabilities & billy.SyncCapability
+	return billy.DefaultCapabilities | billy.SyncCapability
 }
 
 func (fs *BoundOS) Create(name string) (billy.File, error) {
@@ -101,13 +102,7 @@ func (fs *BoundOS) OpenFile(name string, flag int, perm gofs.FileMode) (billy.Fi
 		}
 	}
 
-	if filepath.IsAbs(name) {
-		fn, err := filepath.Rel(fs.baseDir, name)
-		if err != nil {
-			return nil, err
-		}
-		name = fn
-	}
+	name = fs.toRelative(name)
 
 	if flag&os.O_CREATE != 0 {
 		if err = fs.createDir(root, name); err != nil {
@@ -123,14 +118,7 @@ func (fs *BoundOS) OpenFile(name string, flag int, perm gofs.FileMode) (billy.Fi
 }
 
 func (fs *BoundOS) ReadDir(name string) ([]gofs.DirEntry, error) {
-	if filepath.IsAbs(name) {
-		fn, err := filepath.Rel(fs.baseDir, name)
-		if err != nil {
-			return nil, err
-		}
-		name = fn
-	}
-
+	name = fs.toRelative(name)
 	if name == "" {
 		name = "."
 	}
@@ -173,7 +161,7 @@ func (fs *BoundOS) Rename(from, to string) error {
 	return translateError(err, to)
 }
 
-func (fs *BoundOS) MkdirAll(name string, _ gofs.FileMode) error {
+func (fs *BoundOS) MkdirAll(name string, perm gofs.FileMode) error {
 	root, cleanup, err := fs.fsRoot()
 	if err != nil {
 		return err
@@ -181,7 +169,7 @@ func (fs *BoundOS) MkdirAll(name string, _ gofs.FileMode) error {
 	defer cleanup()
 
 	// os.Root errors when perm contains bits other than the nine least-significant bits (0o777).
-	err = root.MkdirAll(name, 0o777)
+	err = root.MkdirAll(name, perm&0o777)
 	return translateError(err, name)
 }
 
@@ -190,22 +178,7 @@ func (fs *BoundOS) Open(name string) (billy.File, error) {
 }
 
 func (fs *BoundOS) Stat(name string) (os.FileInfo, error) {
-	if filepath.IsAbs(name) {
-		fn, err := filepath.Rel(fs.baseDir, name)
-		if err != nil {
-			return nil, err
-		}
-
-		_, err = os.Stat(fs.baseDir)
-		if err != nil && os.IsNotExist(err) {
-			err = os.MkdirAll(fs.baseDir, defaultDirectoryMode)
-			if err != nil {
-				return nil, err
-			}
-		}
-		name = fn
-	}
-
+	name = fs.toRelative(name)
 	if name == "" {
 		name = "."
 	}
@@ -229,13 +202,7 @@ func (fs *BoundOS) Remove(name string) error {
 		return billy.ErrBaseDirCannotBeRemoved
 	}
 
-	if filepath.IsAbs(name) {
-		fn, err := filepath.Rel(fs.baseDir, name)
-		if err != nil {
-			return err
-		}
-		name = fn
-	}
+	name = fs.toRelative(name)
 
 	root, cleanup, err := fs.fsRoot()
 	if err != nil {
@@ -268,13 +235,7 @@ func (fs *BoundOS) RemoveAll(name string) error {
 		return billy.ErrBaseDirCannotBeRemoved
 	}
 
-	if filepath.IsAbs(name) {
-		fn, err := filepath.Rel(fs.baseDir, name)
-		if err != nil {
-			return err
-		}
-		name = fn
-	}
+	name = fs.toRelative(name)
 
 	root, cleanup, err := fs.fsRoot()
 	if err != nil {
@@ -282,17 +243,11 @@ func (fs *BoundOS) RemoveAll(name string) error {
 	}
 	defer cleanup()
 
-	return root.RemoveAll(name)
+	return translateError(root.RemoveAll(name), name)
 }
 
 func (fs *BoundOS) Symlink(oldname, newname string) error {
-	if filepath.IsAbs(newname) {
-		fn, err := filepath.Rel(fs.baseDir, newname)
-		if err != nil {
-			return err
-		}
-		newname = fn
-	}
+	newname = fs.toRelative(newname)
 
 	root, cleanup, err := fs.fsRoot()
 	if err != nil {
@@ -305,17 +260,11 @@ func (fs *BoundOS) Symlink(oldname, newname string) error {
 		return err
 	}
 
-	return root.Symlink(oldname, newname)
+	return translateError(root.Symlink(oldname, newname), newname)
 }
 
 func (fs *BoundOS) Lstat(name string) (os.FileInfo, error) {
-	if filepath.IsAbs(name) {
-		fn, err := filepath.Rel(fs.baseDir, name)
-		if err != nil {
-			return nil, err
-		}
-		name = fn
-	}
+	name = fs.toRelative(name)
 
 	root, cleanup, err := fs.fsRoot()
 	if err != nil {
@@ -381,8 +330,15 @@ func (fs *BoundOS) Chroot(path string) (billy.Filesystem, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to chroot: %w", err)
 	}
-	defer childRoot.Close()
 
+	// When using a caller-provided root (FromRoot mode), preserve that
+	// mode for the child so it reuses a single os.Root rather than
+	// opening and closing one per operation.
+	if fs.root != nil {
+		return FromRoot(childRoot), nil
+	}
+
+	defer childRoot.Close()
 	return New(childRoot.Name(), WithBoundOS()), nil
 }
 
@@ -391,6 +347,17 @@ func (fs *BoundOS) Chroot(path string) (billy.Filesystem, error) {
 // replacement for other upstream implementations (e.g. memory and osfs).
 func (fs *BoundOS) Root() string {
 	return fs.baseDir
+}
+
+// toRelative converts an absolute path to a path relative to the base dir.
+// If the path is already relative it is returned unchanged.
+func (fs *BoundOS) toRelative(name string) string {
+	if filepath.IsAbs(name) {
+		if rel, err := filepath.Rel(fs.baseDir, name); err == nil {
+			return rel
+		}
+	}
+	return name
 }
 
 func (fs *BoundOS) createDir(root *os.Root, fullpath string) error {
@@ -428,7 +395,7 @@ func translateError(err error, file string) error {
 		return nil
 	}
 
-	if errors.Unwrap(err).Error() == ErrPathEscapesParent.Error() {
+	if strings.Contains(err.Error(), ErrPathEscapesParent.Error()) {
 		return fmt.Errorf("%w: %q", ErrPathEscapesParent, file)
 	}
 

--- a/osfs/os_bound.go
+++ b/osfs/os_bound.go
@@ -19,41 +19,20 @@
 package osfs
 
 import (
-	"errors"
-	"fmt"
 	gofs "io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/util"
 )
 
-// ErrPathEscapesParent represents when an action leads to escaping from the
-// given dir the filesystem is bound to.
-//
-// The upstream version of this error used by [os.Root] is not public.
-var ErrPathEscapesParent = errors.New("path escapes from parent")
-
-// FromRoot creates a new instance of BoundOS from an [os.Root].
-// The base dir is set to root.Name(). The provided root is used directly
-// for all operations and the caller is responsible for its lifecycle.
-// If root is nil, all filesystem operations will fail with an error.
-func FromRoot(root *os.Root) billy.Filesystem {
-	if root == nil {
-		return &BoundOS{rootError: errors.New("root is nil")}
-	}
-	return &BoundOS{baseDir: root.Name(), root: root}
-}
-
 // BoundOS is a fs implementation based on the OS filesystem which relies on
-// Go's os.Root. Prefer this fs implementation over ChrootOS.
+// Go's [os.Root]. A new [os.Root] is opened and closed for each filesystem
+// operation to avoid holding a directory handle open.
 //
-// An [os.Root] is opened once and reused for all operations. When created
-// via [FromRoot], the caller is responsible for its lifecycle. When created
-// via [New] with [WithBoundOS], the root is opened eagerly and released by
-// the garbage collector's finalizer (same as [os.File]).
+// For better performance, prefer [RootOS] via [FromRoot] with a
+// caller-managed [os.Root].
 //
 // Behaviours of note:
 //  1. Read and write operations can only be directed to files which descends
@@ -63,17 +42,21 @@ func FromRoot(root *os.Root) billy.Filesystem {
 //  3. Operations leading to escapes to outside the [os.Root] location results
 //     in [ErrPathEscapesParent].
 type BoundOS struct {
-	baseDir   string
-	root      *os.Root
-	rootError error
+	baseDir string
 }
 
 func newBoundOS(d string) billy.Filesystem {
-	r, err := os.OpenRoot(d)
+	return &BoundOS{baseDir: d}
+}
+
+// rootFS opens a temporary [RootOS] and returns a cleanup function that
+// closes the underlying [os.Root].
+func (fs *BoundOS) rootFS() (*RootOS, func(), error) {
+	r, err := os.OpenRoot(fs.baseDir)
 	if err != nil {
-		return &BoundOS{baseDir: d, rootError: err}
+		return nil, func() {}, err
 	}
-	return &BoundOS{baseDir: d, root: r}
+	return &RootOS{root: r}, func() { r.Close() }, nil
 }
 
 func (fs *BoundOS) Capabilities() billy.Capability {
@@ -85,96 +68,39 @@ func (fs *BoundOS) Create(name string) (billy.File, error) {
 }
 
 func (fs *BoundOS) OpenFile(name string, flag int, perm gofs.FileMode) (billy.File, error) {
-	root, err := fs.fsRoot()
+	rfs, cleanup, err := fs.rootFS()
 	if err != nil {
 		return nil, err
 	}
-
-	name = fs.toRelative(name)
-
-	if flag&os.O_CREATE != 0 {
-		if err = fs.createDir(root, name); err != nil {
-			return nil, translateError(err, name)
-		}
-	}
-
-	f, err := root.OpenFile(name, flag, perm)
-	if err == nil {
-		return &file{File: f}, nil
-	}
-
-	// When the open fails because the path escapes the root, the file
-	// may be a symlink whose target is an absolute path that actually
-	// resides inside the root. Resolve the link and retry.
-	if flag&os.O_CREATE == 0 && isPathEscapeError(err) {
-		fi, lstatErr := root.Lstat(name)
-		if lstatErr == nil && fi.Mode()&gofs.ModeSymlink != 0 {
-			if fn, rlErr := root.Readlink(name); rlErr == nil {
-				fn = fs.toRelative(fn)
-				if f, err = root.OpenFile(fn, flag, perm); err == nil {
-					return &file{File: f}, nil
-				}
-			}
-		}
-	}
-
-	return nil, translateError(err, name)
+	defer cleanup()
+	return rfs.OpenFile(name, flag, perm)
 }
 
 func (fs *BoundOS) ReadDir(name string) ([]gofs.DirEntry, error) {
-	name = fs.toRelative(name)
-	if name == "" {
-		name = "."
-	}
-
-	root, err := fs.fsRoot()
+	rfs, cleanup, err := fs.rootFS()
 	if err != nil {
 		return nil, err
 	}
-
-	f, err := root.Open(name)
-	if err != nil {
-		return nil, translateError(err, name)
-	}
-
-	e, err := f.ReadDir(-1)
-	if err != nil {
-		return nil, translateError(err, name)
-	}
-	return e, nil
+	defer cleanup()
+	return rfs.ReadDir(name)
 }
 
 func (fs *BoundOS) Rename(from, to string) error {
-	if from == "." || from == fs.baseDir {
-		return billy.ErrBaseDirCannotBeRenamed
-	}
-
-	from = fs.toRelative(from)
-	to = fs.toRelative(to)
-
-	root, err := fs.fsRoot()
+	rfs, cleanup, err := fs.rootFS()
 	if err != nil {
 		return err
 	}
-
-	// Ensure the target directory exists.
-	err = root.MkdirAll(filepath.Dir(to), defaultDirectoryMode)
-	if err == nil {
-		err = root.Rename(from, to)
-	}
-
-	return translateError(err, to)
+	defer cleanup()
+	return rfs.Rename(from, to)
 }
 
 func (fs *BoundOS) MkdirAll(name string, perm gofs.FileMode) error {
-	root, err := fs.fsRoot()
+	rfs, cleanup, err := fs.rootFS()
 	if err != nil {
 		return err
 	}
-
-	// os.Root errors when perm contains bits other than the nine least-significant bits (0o777).
-	err = root.MkdirAll(name, perm&0o777)
-	return translateError(err, name)
+	defer cleanup()
+	return rfs.MkdirAll(name, perm)
 }
 
 func (fs *BoundOS) Open(name string) (billy.File, error) {
@@ -182,42 +108,21 @@ func (fs *BoundOS) Open(name string) (billy.File, error) {
 }
 
 func (fs *BoundOS) Stat(name string) (os.FileInfo, error) {
-	name = fs.toRelative(name)
-	if name == "" {
-		name = "."
-	}
-
-	root, err := fs.fsRoot()
+	rfs, cleanup, err := fs.rootFS()
 	if err != nil {
 		return nil, err
 	}
-
-	fi, err := root.Stat(name)
-	if err != nil {
-		return nil, translateError(err, name)
-	}
-
-	return fi, nil
+	defer cleanup()
+	return rfs.Stat(name)
 }
 
 func (fs *BoundOS) Remove(name string) error {
-	if name == "." || name == fs.baseDir {
-		return billy.ErrBaseDirCannotBeRemoved
-	}
-
-	name = fs.toRelative(name)
-
-	root, err := fs.fsRoot()
+	rfs, cleanup, err := fs.rootFS()
 	if err != nil {
 		return err
 	}
-
-	err = root.Remove(name)
-	if err == nil {
-		return nil
-	}
-
-	return translateError(err, name)
+	defer cleanup()
+	return rfs.Remove(name)
 }
 
 // TempFile creates a temporary file. If dir is empty, the file
@@ -233,156 +138,69 @@ func (fs *BoundOS) Join(elem ...string) string {
 }
 
 func (fs *BoundOS) RemoveAll(name string) error {
-	if name == "." || name == fs.baseDir {
-		return billy.ErrBaseDirCannotBeRemoved
-	}
-
-	name = fs.toRelative(name)
-
-	root, err := fs.fsRoot()
+	rfs, cleanup, err := fs.rootFS()
 	if err != nil {
 		return err
 	}
-
-	return translateError(root.RemoveAll(name), name)
+	defer cleanup()
+	return rfs.RemoveAll(name)
 }
 
 func (fs *BoundOS) Symlink(oldname, newname string) error {
-	newname = fs.toRelative(newname)
-
-	root, err := fs.fsRoot()
+	rfs, cleanup, err := fs.rootFS()
 	if err != nil {
 		return err
 	}
-
-	err = fs.createDir(root, newname)
-	if err != nil {
-		return err
-	}
-
-	return translateError(root.Symlink(oldname, newname), newname)
+	defer cleanup()
+	return rfs.Symlink(oldname, newname)
 }
 
 func (fs *BoundOS) Lstat(name string) (os.FileInfo, error) {
-	name = fs.toRelative(name)
-
-	root, err := fs.fsRoot()
+	rfs, cleanup, err := fs.rootFS()
 	if err != nil {
 		return nil, err
 	}
-
-	fi, err := root.Lstat(name)
-	if err != nil {
-		return nil, translateError(err, name)
-	}
-
-	return fi, nil
+	defer cleanup()
+	return rfs.Lstat(name)
 }
 
 func (fs *BoundOS) Readlink(name string) (string, error) {
-	name = fs.toRelative(name)
-
-	root, err := fs.fsRoot()
+	rfs, cleanup, err := fs.rootFS()
 	if err != nil {
 		return "", err
 	}
-
-	lnk, err := root.Readlink(name)
-	if err != nil {
-		return "", translateError(err, name)
-	}
-
-	return lnk, nil
+	defer cleanup()
+	return rfs.Readlink(name)
 }
 
 func (fs *BoundOS) Chmod(path string, mode gofs.FileMode) error {
-	path = fs.toRelative(path)
-
-	root, err := fs.fsRoot()
+	rfs, cleanup, err := fs.rootFS()
 	if err != nil {
 		return err
 	}
-	return root.Chmod(path, mode)
+	defer cleanup()
+	return rfs.Chmod(path, mode)
 }
 
-// Chroot returns a new BoundOS filesystem, with the base dir set to the
+// Chroot returns a new [BoundOS] filesystem, with the base dir set to the
 // result of joining the provided path with the underlying base dir.
 func (fs *BoundOS) Chroot(path string) (billy.Filesystem, error) {
-	root, err := fs.fsRoot()
+	rfs, cleanup, err := fs.rootFS()
 	if err != nil {
 		return nil, err
 	}
+	defer cleanup()
 
-	fi, err := root.Lstat(path)
-	if errors.Is(err, os.ErrNotExist) {
-		err := root.MkdirAll(path, defaultDirectoryMode)
-		if err != nil {
-			return nil, fmt.Errorf("failed to auto create dir: %w", err)
-		}
-	} else if err != nil {
+	childRoot, err := openChildRoot(rfs.root, path)
+	if err != nil {
 		return nil, err
 	}
-	if fi != nil && !fi.IsDir() {
-		return nil, fmt.Errorf("cannot chroot: path is not dir")
-	}
+	defer childRoot.Close()
 
-	childRoot, err := root.OpenRoot(path)
-	if err != nil {
-		return nil, fmt.Errorf("unable to chroot: %w", err)
-	}
-
-	return FromRoot(childRoot), nil
+	return newBoundOS(childRoot.Name()), nil
 }
 
 // Root returns the current base dir of the billy.Filesystem.
-// This is required in order for this implementation to be a drop-in
-// replacement for other upstream implementations (e.g. memory and osfs).
 func (fs *BoundOS) Root() string {
 	return fs.baseDir
-}
-
-// toRelative converts an absolute path to a path relative to the base dir.
-// If the path is already relative it is returned unchanged.
-func (fs *BoundOS) toRelative(name string) string {
-	if filepath.IsAbs(name) {
-		if rel, err := filepath.Rel(fs.baseDir, name); err == nil {
-			return rel
-		}
-	}
-	return name
-}
-
-func (fs *BoundOS) createDir(root *os.Root, fullpath string) error {
-	dir := filepath.Dir(fullpath)
-	if dir != "." {
-		if err := root.MkdirAll(dir, defaultDirectoryMode); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// fsRoot returns the [os.Root] to use for filesystem operations.
-func (fs *BoundOS) fsRoot() (*os.Root, error) {
-	if fs.rootError != nil {
-		return nil, fs.rootError
-	}
-	return fs.root, nil
-}
-
-func isPathEscapeError(err error) bool {
-	return err != nil && strings.Contains(err.Error(), ErrPathEscapesParent.Error())
-}
-
-func translateError(err error, file string) error {
-	if err == nil {
-		return nil
-	}
-
-	if isPathEscapeError(err) {
-		return fmt.Errorf("%w: %q", ErrPathEscapesParent, file)
-	}
-
-	return err
 }

--- a/osfs/os_bound.go
+++ b/osfs/os_bound.go
@@ -37,11 +37,9 @@ import (
 var ErrPathEscapesParent = errors.New("path escapes from parent")
 
 // FromRoot creates a new instance of BoundOS from an [os.Root].
-// The base dir is set to root.Name(). Unlike [New] with [WithBoundOS],
-// the provided root is used directly for all operations rather than
-// opening a fresh [os.Root] per operation; the caller is responsible
-// for the root's lifecycle. If root is nil, all filesystem operations
-// will fail with an error.
+// The base dir is set to root.Name(). The provided root is used directly
+// for all operations and the caller is responsible for its lifecycle.
+// If root is nil, all filesystem operations will fail with an error.
 func FromRoot(root *os.Root) billy.Filesystem {
 	if root == nil {
 		return &BoundOS{rootError: errors.New("root is nil")}
@@ -52,10 +50,10 @@ func FromRoot(root *os.Root) billy.Filesystem {
 // BoundOS is a fs implementation based on the OS filesystem which relies on
 // Go's os.Root. Prefer this fs implementation over ChrootOS.
 //
-// When created via [New] with [WithBoundOS], a new [os.Root] is opened and
-// closed for each filesystem operation. When created via [FromRoot], the
-// provided [os.Root] is used directly for all operations and the caller is
-// responsible for its lifecycle.
+// An [os.Root] is opened once and reused for all operations. When created
+// via [FromRoot], the caller is responsible for its lifecycle. When created
+// via [New] with [WithBoundOS], the root is opened eagerly and released by
+// the garbage collector's finalizer (same as [os.File]).
 //
 // Behaviours of note:
 //  1. Read and write operations can only be directed to files which descends
@@ -66,12 +64,16 @@ func FromRoot(root *os.Root) billy.Filesystem {
 //     in [ErrPathEscapesParent].
 type BoundOS struct {
 	baseDir   string
-	root      *os.Root // non-nil only for FromRoot; newBoundOS opens per-op
+	root      *os.Root
 	rootError error
 }
 
 func newBoundOS(d string) billy.Filesystem {
-	return &BoundOS{baseDir: d}
+	r, err := os.OpenRoot(d)
+	if err != nil {
+		return &BoundOS{baseDir: d, rootError: err}
+	}
+	return &BoundOS{baseDir: d, root: r}
 }
 
 func (fs *BoundOS) Capabilities() billy.Capability {
@@ -83,23 +85,9 @@ func (fs *BoundOS) Create(name string) (billy.File, error) {
 }
 
 func (fs *BoundOS) OpenFile(name string, flag int, perm gofs.FileMode) (billy.File, error) {
-	root, cleanup, err := fs.fsRoot()
+	root, err := fs.fsRoot()
 	if err != nil {
 		return nil, err
-	}
-	defer cleanup()
-
-	// When not creating, read symlink links so that they can be made
-	// relative and therefore work.
-	if flag&os.O_CREATE == 0 {
-		fi, err := root.Lstat(name)
-		if err == nil && fi.Mode()&gofs.ModeSymlink != 0 {
-			fn, err := root.Readlink(name)
-			if err != nil {
-				return nil, err
-			}
-			name = fn
-		}
 	}
 
 	name = fs.toRelative(name)
@@ -111,10 +99,26 @@ func (fs *BoundOS) OpenFile(name string, flag int, perm gofs.FileMode) (billy.Fi
 	}
 
 	f, err := root.OpenFile(name, flag, perm)
-	if err != nil {
-		return nil, err
+	if err == nil {
+		return &file{File: f}, nil
 	}
-	return &file{File: f}, nil
+
+	// When the open fails because the path escapes the root, the file
+	// may be a symlink whose target is an absolute path that actually
+	// resides inside the root. Resolve the link and retry.
+	if flag&os.O_CREATE == 0 && isPathEscapeError(err) {
+		fi, lstatErr := root.Lstat(name)
+		if lstatErr == nil && fi.Mode()&gofs.ModeSymlink != 0 {
+			if fn, rlErr := root.Readlink(name); rlErr == nil {
+				fn = fs.toRelative(fn)
+				if f, err = root.OpenFile(fn, flag, perm); err == nil {
+					return &file{File: f}, nil
+				}
+			}
+		}
+	}
+
+	return nil, translateError(err, name)
 }
 
 func (fs *BoundOS) ReadDir(name string) ([]gofs.DirEntry, error) {
@@ -123,11 +127,10 @@ func (fs *BoundOS) ReadDir(name string) ([]gofs.DirEntry, error) {
 		name = "."
 	}
 
-	root, cleanup, err := fs.fsRoot()
+	root, err := fs.fsRoot()
 	if err != nil {
 		return nil, err
 	}
-	defer cleanup()
 
 	f, err := root.Open(name)
 	if err != nil {
@@ -146,11 +149,13 @@ func (fs *BoundOS) Rename(from, to string) error {
 		return billy.ErrBaseDirCannotBeRenamed
 	}
 
-	root, cleanup, err := fs.fsRoot()
+	from = fs.toRelative(from)
+	to = fs.toRelative(to)
+
+	root, err := fs.fsRoot()
 	if err != nil {
 		return err
 	}
-	defer cleanup()
 
 	// Ensure the target directory exists.
 	err = root.MkdirAll(filepath.Dir(to), defaultDirectoryMode)
@@ -162,11 +167,10 @@ func (fs *BoundOS) Rename(from, to string) error {
 }
 
 func (fs *BoundOS) MkdirAll(name string, perm gofs.FileMode) error {
-	root, cleanup, err := fs.fsRoot()
+	root, err := fs.fsRoot()
 	if err != nil {
 		return err
 	}
-	defer cleanup()
 
 	// os.Root errors when perm contains bits other than the nine least-significant bits (0o777).
 	err = root.MkdirAll(name, perm&0o777)
@@ -183,11 +187,10 @@ func (fs *BoundOS) Stat(name string) (os.FileInfo, error) {
 		name = "."
 	}
 
-	root, cleanup, err := fs.fsRoot()
+	root, err := fs.fsRoot()
 	if err != nil {
 		return nil, err
 	}
-	defer cleanup()
 
 	fi, err := root.Stat(name)
 	if err != nil {
@@ -204,11 +207,10 @@ func (fs *BoundOS) Remove(name string) error {
 
 	name = fs.toRelative(name)
 
-	root, cleanup, err := fs.fsRoot()
+	root, err := fs.fsRoot()
 	if err != nil {
 		return err
 	}
-	defer cleanup()
 
 	err = root.Remove(name)
 	if err == nil {
@@ -237,11 +239,10 @@ func (fs *BoundOS) RemoveAll(name string) error {
 
 	name = fs.toRelative(name)
 
-	root, cleanup, err := fs.fsRoot()
+	root, err := fs.fsRoot()
 	if err != nil {
 		return err
 	}
-	defer cleanup()
 
 	return translateError(root.RemoveAll(name), name)
 }
@@ -249,11 +250,10 @@ func (fs *BoundOS) RemoveAll(name string) error {
 func (fs *BoundOS) Symlink(oldname, newname string) error {
 	newname = fs.toRelative(newname)
 
-	root, cleanup, err := fs.fsRoot()
+	root, err := fs.fsRoot()
 	if err != nil {
 		return err
 	}
-	defer cleanup()
 
 	err = fs.createDir(root, newname)
 	if err != nil {
@@ -266,11 +266,10 @@ func (fs *BoundOS) Symlink(oldname, newname string) error {
 func (fs *BoundOS) Lstat(name string) (os.FileInfo, error) {
 	name = fs.toRelative(name)
 
-	root, cleanup, err := fs.fsRoot()
+	root, err := fs.fsRoot()
 	if err != nil {
 		return nil, err
 	}
-	defer cleanup()
 
 	fi, err := root.Lstat(name)
 	if err != nil {
@@ -281,11 +280,12 @@ func (fs *BoundOS) Lstat(name string) (os.FileInfo, error) {
 }
 
 func (fs *BoundOS) Readlink(name string) (string, error) {
-	root, cleanup, err := fs.fsRoot()
+	name = fs.toRelative(name)
+
+	root, err := fs.fsRoot()
 	if err != nil {
 		return "", err
 	}
-	defer cleanup()
 
 	lnk, err := root.Readlink(name)
 	if err != nil {
@@ -296,22 +296,22 @@ func (fs *BoundOS) Readlink(name string) (string, error) {
 }
 
 func (fs *BoundOS) Chmod(path string, mode gofs.FileMode) error {
-	root, cleanup, err := fs.fsRoot()
+	path = fs.toRelative(path)
+
+	root, err := fs.fsRoot()
 	if err != nil {
 		return err
 	}
-	defer cleanup()
 	return root.Chmod(path, mode)
 }
 
 // Chroot returns a new BoundOS filesystem, with the base dir set to the
 // result of joining the provided path with the underlying base dir.
 func (fs *BoundOS) Chroot(path string) (billy.Filesystem, error) {
-	root, cleanup, err := fs.fsRoot()
+	root, err := fs.fsRoot()
 	if err != nil {
 		return nil, err
 	}
-	defer cleanup()
 
 	fi, err := root.Lstat(path)
 	if errors.Is(err, os.ErrNotExist) {
@@ -331,15 +331,7 @@ func (fs *BoundOS) Chroot(path string) (billy.Filesystem, error) {
 		return nil, fmt.Errorf("unable to chroot: %w", err)
 	}
 
-	// When using a caller-provided root (FromRoot mode), preserve that
-	// mode for the child so it reuses a single os.Root rather than
-	// opening and closing one per operation.
-	if fs.root != nil {
-		return FromRoot(childRoot), nil
-	}
-
-	defer childRoot.Close()
-	return New(childRoot.Name(), WithBoundOS()), nil
+	return FromRoot(childRoot), nil
 }
 
 // Root returns the current base dir of the billy.Filesystem.
@@ -371,23 +363,16 @@ func (fs *BoundOS) createDir(root *os.Root, fullpath string) error {
 	return nil
 }
 
-// fsRoot returns the [os.Root] to use for filesystem operations along with
-// a cleanup function that must be called when the root is no longer needed.
-// For BoundOS instances created via [FromRoot], the cleanup is a no-op and
-// the caller-provided root is returned directly. Otherwise, a new [os.Root]
-// is opened for each call and closed by the cleanup function.
-func (fs *BoundOS) fsRoot() (*os.Root, func(), error) {
+// fsRoot returns the [os.Root] to use for filesystem operations.
+func (fs *BoundOS) fsRoot() (*os.Root, error) {
 	if fs.rootError != nil {
-		return nil, func() {}, fs.rootError
+		return nil, fs.rootError
 	}
-	if fs.root != nil {
-		return fs.root, func() {}, nil
-	}
-	r, err := os.OpenRoot(fs.baseDir)
-	if err != nil {
-		return nil, func() {}, err
-	}
-	return r, func() { r.Close() }, nil
+	return fs.root, nil
+}
+
+func isPathEscapeError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), ErrPathEscapesParent.Error())
 }
 
 func translateError(err error, file string) error {
@@ -395,7 +380,7 @@ func translateError(err error, file string) error {
 		return nil
 	}
 
-	if strings.Contains(err.Error(), ErrPathEscapesParent.Error()) {
+	if isPathEscapeError(err) {
 		return fmt.Errorf("%w: %q", ErrPathEscapesParent, file)
 	}
 

--- a/osfs/os_bound_test.go
+++ b/osfs/os_bound_test.go
@@ -41,61 +41,46 @@ func TestBoundOSCapabilities(t *testing.T) {
 }
 
 func TestFromRoot(t *testing.T) {
-	validRoot, err := os.OpenRoot(t.TempDir())
-	require.NoError(t, err)
-	t.Cleanup(func() { validRoot.Close() })
+	t.Parallel()
 
-	closedRoot, err := os.OpenRoot(t.TempDir())
-	require.NoError(t, err)
-	require.NoError(t, closedRoot.Close())
+	t.Run("valid root", func(t *testing.T) {
+		t.Parallel()
+		root, err := os.OpenRoot(t.TempDir())
+		require.NoError(t, err)
+		t.Cleanup(func() { root.Close() })
 
-	tests := []struct {
-		name     string
-		root     *os.Root
-		wantRoot string
-		wantErr  string
-	}{
-		{
-			name:     "valid root",
-			root:     validRoot,
-			wantRoot: validRoot.Name(),
-		},
-		{
-			name:    "nil root",
-			root:    nil,
-			wantErr: "root is nil",
-		},
-		{
-			name:     "closed root",
-			root:     closedRoot,
-			wantRoot: closedRoot.Name(),
-			wantErr:  "file already closed",
-		},
-	}
+		fs, err := FromRoot(root)
+		require.NoError(t, err)
+		assert.IsType(t, &RootOS{}, fs)
+		assert.Equal(t, root.Name(), fs.Root())
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert := assert.New(t)
+		f, err := fs.Create("test-file")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
 
-			fs := FromRoot(tt.root)
-			require.NotNil(t, fs)
-			assert.IsType(&BoundOS{}, fs)
-			assert.Equal(tt.wantRoot, fs.Root())
+		_, err = fs.Stat("test-file")
+		require.NoError(t, err)
+	})
 
-			if tt.wantErr != "" {
-				_, err := fs.Stat(".")
-				require.ErrorContains(t, err, tt.wantErr)
-				return
-			}
+	t.Run("nil root", func(t *testing.T) {
+		t.Parallel()
+		_, err := FromRoot(nil)
+		require.Error(t, err)
+	})
 
-			f, err := fs.Create("test-file")
-			require.NoError(t, err)
-			require.NoError(t, f.Close())
+	t.Run("closed root", func(t *testing.T) {
+		t.Parallel()
+		root, err := os.OpenRoot(t.TempDir())
+		require.NoError(t, err)
+		require.NoError(t, root.Close())
 
-			_, err = fs.Stat("test-file")
-			require.NoError(t, err)
-		})
-	}
+		fs, err := FromRoot(root)
+		require.NoError(t, err)
+		assert.Equal(t, root.Name(), fs.Root())
+
+		_, err = fs.Stat(".")
+		require.ErrorContains(t, err, "file already closed")
+	})
 }
 
 // TestOpenAbsSymlinkInsideRoot verifies that Open can follow a symlink whose

--- a/osfs/os_bound_test.go
+++ b/osfs/os_bound_test.go
@@ -37,7 +37,7 @@ func TestBoundOSCapabilities(t *testing.T) {
 	assert.True(t, ok)
 
 	caps := c.Capabilities()
-	assert.Equal(t, billy.DefaultCapabilities&billy.SyncCapability, caps)
+	assert.Equal(t, billy.DefaultCapabilities|billy.SyncCapability, caps)
 }
 
 func TestFromRoot(t *testing.T) {
@@ -381,18 +381,16 @@ func TestTempFile(t *testing.T) {
 	require.ErrorIs(t, err, ErrPathEscapesParent)
 	assert.Nil(f)
 
-	dir = os.TempDir()
 	f, err = fs.TempFile("../../../above/cwd", "prefix")
 	require.ErrorIs(t, err, ErrPathEscapesParent)
 	assert.Nil(f)
-
-	dir = filepath.Join(dir, "/tmp")
+	outsideDir := filepath.Join(os.TempDir(), "/tmp")
 	// For windows, volume name must be removed.
-	if v := filepath.VolumeName(dir); v != "" {
-		dir = strings.TrimPrefix(dir, v)
+	if v := filepath.VolumeName(outsideDir); v != "" {
+		outsideDir = strings.TrimPrefix(outsideDir, v)
 	}
 
-	f, err = fs.TempFile(dir, "prefix")
+	f, err = fs.TempFile(outsideDir, "prefix")
 	require.ErrorIs(t, err, ErrPathEscapesParent)
 	assert.Nil(f)
 }

--- a/osfs/os_bound_test.go
+++ b/osfs/os_bound_test.go
@@ -98,6 +98,39 @@ func TestFromRoot(t *testing.T) {
 	}
 }
 
+// TestOpenAbsSymlinkInsideRoot verifies that Open can follow a symlink whose
+// target is an absolute path pointing inside the root. os.Root rejects such
+// symlinks because the absolute target appears to escape the root. BoundOS
+// detects this, resolves the link to a relative path, and retries.
+func TestOpenAbsSymlinkInsideRoot(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	absTarget := filepath.Join(dir, "target")
+	require.NoError(t, os.WriteFile(absTarget, []byte("content"), 0o600))
+	require.NoError(t, os.Symlink(absTarget, filepath.Join(dir, "link")))
+
+	// Prove os.Root alone rejects the absolute symlink target.
+	root, err := os.OpenRoot(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { root.Close() })
+
+	_, err = root.Open("link")
+	require.Error(t, err, "os.Root.Open must reject an absolute symlink target inside the root")
+	require.ErrorContains(t, err, ErrPathEscapesParent.Error())
+
+	// BoundOS resolves the absolute target to a relative path and succeeds.
+	bfs := newBoundOS(dir)
+	f, err := bfs.Open("link")
+	require.NoError(t, err)
+
+	got := make([]byte, 7)
+	_, err = f.Read(got)
+	require.NoError(t, err)
+	assert.Equal(t, "content", string(got))
+	require.NoError(t, f.Close())
+}
+
 func TestOpen(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -451,7 +484,6 @@ func TestReadLink(t *testing.T) {
 			filename: "symlink",
 			makeAbs:  true,
 			expected: filepath.FromSlash("/etc/passwd"),
-			wantErr:  ErrPathEscapesParent,
 		},
 		{
 			name: "symlink: dir pointing outside cwd",
@@ -1219,6 +1251,31 @@ func TestMkdirAll(t *testing.T) {
 
 	fi, _ = os.Stat(filepath.Join(root, "outside", "new-dir"))
 	require.Nil(t, fi, "dir must not be created")
+}
+
+func TestRenameAbsSource(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	fs := newBoundOS(dir)
+
+	f, err := fs.TempFile("", "tmp-")
+	require.NoError(t, err)
+	_, err = f.Write([]byte("data"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// File.Name() returns an absolute path from os.Root.
+	require.True(t, filepath.IsAbs(f.Name()),
+		"expected absolute path from File.Name(), got %q", f.Name())
+
+	dst := filepath.Join("objects", "a8", "finalfile")
+	err = fs.Rename(f.Name(), dst)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(filepath.Join(dir, dst))
+	require.NoError(t, err)
+	assert.Equal(t, "data", string(got))
 }
 
 func TestRename(t *testing.T) {

--- a/osfs/os_options.go
+++ b/osfs/os_options.go
@@ -1,3 +1,28 @@
 package osfs
 
 type Option func(*options)
+
+// WithBoundOS returns the option of using a Bound filesystem OS.
+func WithBoundOS() Option {
+	return func(o *options) {
+		o.Type = BoundOSFS
+	}
+}
+
+// WithChrootOS returns the option of using a Chroot filesystem OS.
+func WithChrootOS() Option {
+	return func(o *options) {
+		o.Type = ChrootOSFS
+	}
+}
+
+type options struct {
+	Type
+}
+
+type Type int
+
+const (
+	ChrootOSFS Type = iota
+	BoundOSFS
+)

--- a/osfs/os_rootfs.go
+++ b/osfs/os_rootfs.go
@@ -1,0 +1,297 @@
+//go:build !js
+
+package osfs
+
+import (
+	"errors"
+	"fmt"
+	gofs "io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/util"
+)
+
+// ErrPathEscapesParent represents when an action leads to escaping from the
+// given dir the filesystem is bound to.
+//
+// The upstream version of this error used by [os.Root] is not public.
+var ErrPathEscapesParent = errors.New("path escapes from parent")
+
+// FromRoot creates a new [RootOS] from an [os.Root].
+// The provided root is used directly for all operations and the caller
+// is responsible for its lifecycle. Root must not be nil.
+func FromRoot(root *os.Root) (*RootOS, error) {
+	if root == nil {
+		return nil, errors.New("root must not be nil")
+	}
+	return &RootOS{root: root}, nil
+}
+
+// RootOS is a high-performance fs implementation based on a caller-managed
+// [os.Root]. Since the root is reused across all operations, this avoids
+// the overhead of opening and closing it on every call. The caller is
+// responsible for the root's lifecycle.
+//
+// For automatic lifecycle management at the cost of per-operation overhead,
+// use [BoundOS] via [New] with [WithBoundOS] instead.
+//
+// Behaviours of note:
+//  1. Read and write operations can only be directed to files which descends
+//     from the root dir.
+//  2. Symlinks don't have their targets modified, and therefore can point
+//     to locations outside the root dir or to non-existent paths.
+//  3. Operations leading to escapes to outside the [os.Root] location results
+//     in [ErrPathEscapesParent].
+type RootOS struct {
+	root *os.Root
+}
+
+func (fs *RootOS) Capabilities() billy.Capability {
+	return billy.DefaultCapabilities | billy.SyncCapability
+}
+
+func (fs *RootOS) Create(name string) (billy.File, error) {
+	return fs.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, defaultCreateMode)
+}
+
+func (fs *RootOS) OpenFile(name string, flag int, perm gofs.FileMode) (billy.File, error) {
+	name = fs.toRelative(name)
+
+	if flag&os.O_CREATE != 0 {
+		if err := createDir(fs.root, name); err != nil {
+			return nil, translateError(err, name)
+		}
+	}
+
+	f, err := fs.root.OpenFile(name, flag, perm)
+	if err == nil {
+		return &file{File: f}, nil
+	}
+
+	// When the open fails because the path escapes the root, the file
+	// may be a symlink whose target is an absolute path that actually
+	// resides inside the root. Resolve the link and retry.
+	if flag&os.O_CREATE == 0 && isPathEscapeError(err) {
+		fi, lstatErr := fs.root.Lstat(name)
+		if lstatErr == nil && fi.Mode()&gofs.ModeSymlink != 0 {
+			if fn, rlErr := fs.root.Readlink(name); rlErr == nil {
+				fn = fs.toRelative(fn)
+				if f, err = fs.root.OpenFile(fn, flag, perm); err == nil {
+					return &file{File: f}, nil
+				}
+			}
+		}
+	}
+
+	return nil, translateError(err, name)
+}
+
+func (fs *RootOS) ReadDir(name string) ([]gofs.DirEntry, error) {
+	name = fs.toRelative(name)
+	if name == "" {
+		name = "."
+	}
+
+	f, err := fs.root.Open(name)
+	if err != nil {
+		return nil, translateError(err, name)
+	}
+	defer f.Close()
+
+	e, err := f.ReadDir(-1)
+	if err != nil {
+		return nil, translateError(err, name)
+	}
+	return e, nil
+}
+
+func (fs *RootOS) Rename(from, to string) error {
+	if from == "." || from == fs.Root() {
+		return billy.ErrBaseDirCannotBeRenamed
+	}
+
+	from = fs.toRelative(from)
+	to = fs.toRelative(to)
+
+	// Ensure the target directory exists.
+	err := fs.root.MkdirAll(filepath.Dir(to), defaultDirectoryMode)
+	if err == nil {
+		err = fs.root.Rename(from, to)
+	}
+
+	return translateError(err, to)
+}
+
+func (fs *RootOS) MkdirAll(name string, perm gofs.FileMode) error {
+	// os.Root errors when perm contains bits other than the nine least-significant bits (0o777).
+	err := fs.root.MkdirAll(name, perm&0o777)
+	return translateError(err, name)
+}
+
+func (fs *RootOS) Open(name string) (billy.File, error) {
+	return fs.OpenFile(name, os.O_RDONLY, 0)
+}
+
+func (fs *RootOS) Stat(name string) (os.FileInfo, error) {
+	name = fs.toRelative(name)
+	if name == "" {
+		name = "."
+	}
+
+	fi, err := fs.root.Stat(name)
+	if err != nil {
+		return nil, translateError(err, name)
+	}
+
+	return fi, nil
+}
+
+func (fs *RootOS) Remove(name string) error {
+	if name == "." || name == fs.Root() {
+		return billy.ErrBaseDirCannotBeRemoved
+	}
+
+	name = fs.toRelative(name)
+
+	err := fs.root.Remove(name)
+	if err == nil {
+		return nil
+	}
+
+	return translateError(err, name)
+}
+
+// TempFile creates a temporary file. If dir is empty, the file
+// will be created within a .tmp dir.
+//
+// If dir is outside the root dir, [ErrPathEscapesParent] is returned.
+func (fs *RootOS) TempFile(dir, prefix string) (billy.File, error) {
+	return util.TempFile(fs, dir, prefix)
+}
+
+func (fs *RootOS) Join(elem ...string) string {
+	return filepath.Join(elem...)
+}
+
+func (fs *RootOS) RemoveAll(name string) error {
+	if name == "." || name == fs.Root() {
+		return billy.ErrBaseDirCannotBeRemoved
+	}
+
+	name = fs.toRelative(name)
+	return translateError(fs.root.RemoveAll(name), name)
+}
+
+func (fs *RootOS) Symlink(oldname, newname string) error {
+	newname = fs.toRelative(newname)
+
+	if err := createDir(fs.root, newname); err != nil {
+		return err
+	}
+
+	return translateError(fs.root.Symlink(oldname, newname), newname)
+}
+
+func (fs *RootOS) Lstat(name string) (os.FileInfo, error) {
+	name = fs.toRelative(name)
+
+	fi, err := fs.root.Lstat(name)
+	if err != nil {
+		return nil, translateError(err, name)
+	}
+
+	return fi, nil
+}
+
+func (fs *RootOS) Readlink(name string) (string, error) {
+	name = fs.toRelative(name)
+
+	lnk, err := fs.root.Readlink(name)
+	if err != nil {
+		return "", translateError(err, name)
+	}
+
+	return lnk, nil
+}
+
+func (fs *RootOS) Chmod(path string, mode gofs.FileMode) error {
+	path = fs.toRelative(path)
+	return fs.root.Chmod(path, mode)
+}
+
+// Chroot returns a new [RootOS] filesystem, with the root set to the
+// result of joining the provided path with the underlying root dir.
+func (fs *RootOS) Chroot(path string) (billy.Filesystem, error) {
+	childRoot, err := openChildRoot(fs.root, path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RootOS{root: childRoot}, nil
+}
+
+// Root returns the current root dir of the filesystem.
+func (fs *RootOS) Root() string {
+	return fs.root.Name()
+}
+
+func (fs *RootOS) toRelative(name string) string {
+	if filepath.IsAbs(name) {
+		if rel, err := filepath.Rel(fs.root.Name(), name); err == nil {
+			return rel
+		}
+	}
+	return name
+}
+
+// openChildRoot validates path and opens a child [os.Root].
+func openChildRoot(root *os.Root, path string) (*os.Root, error) {
+	fi, err := root.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		err = root.MkdirAll(path, defaultDirectoryMode)
+		if err != nil {
+			return nil, fmt.Errorf("failed to auto create dir: %w", err)
+		}
+	} else if err != nil {
+		return nil, err
+	}
+	if fi != nil && !fi.IsDir() {
+		return nil, fmt.Errorf("cannot chroot: path is not dir")
+	}
+
+	childRoot, err := root.OpenRoot(path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to chroot: %w", err)
+	}
+	return childRoot, nil
+}
+
+func createDir(root *os.Root, fullpath string) error {
+	dir := filepath.Dir(fullpath)
+	if dir != "." {
+		if err := root.MkdirAll(dir, defaultDirectoryMode); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func isPathEscapeError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), ErrPathEscapesParent.Error())
+}
+
+func translateError(err error, file string) error {
+	if err == nil {
+		return nil
+	}
+
+	if isPathEscapeError(err) {
+		return fmt.Errorf("%w: %q", ErrPathEscapesParent, file)
+	}
+
+	return err
+}


### PR DESCRIPTION
This change removes the previous on-demand costly evaluation of paths and replaces it with Go's traversal resistent primitive `os.Root`.

The benchmark tests in `/test/` show that in most scenarios this has a positive performance impact. The numbers below are based using `FromRoot` which enables reuse of an active `os.Root` across several operations:
```
                                 │   base.txt    │                pr.txt                 │
                                 │    sec/op     │     sec/op      vs base               │
Compare/osfs.boundOS_open-4        15.78µ ±   4%    13.38µ ±   2%  -15.22% (p=0.002 n=6)
Compare/osfs.boundOS_read-4        88.45µ ±   1%    91.08µ ±   0%   +2.97% (p=0.002 n=6)
Compare/osfs.boundOS_write-4       924.4µ ±  23%    867.2µ ±  18%        ~ (p=0.180 n=6)
Compare/osfs.boundOS_create-4      31.39µ ±  51%    23.10µ ±  72%        ~ (p=0.065 n=6)
Compare/osfs.boundOS_stat-4        9.493µ ±   2%    4.244µ ±   2%  -55.30% (p=0.002 n=6)
Compare/osfs.boundOS_rename-4      68.14µ ±   1%    42.76µ ±   3%  -37.26% (p=0.002 n=6)
Compare/osfs.boundOS_remove-4      30.14µ ±   2%    24.31µ ±   3%  -19.34% (p=0.002 n=6)
Compare/osfs.boundOS_mkdirall-4    18.25µ ± 351%    17.74µ ± 303%        ~ (p=0.699 n=6)
Compare/osfs.boundOS_tempfile-4    39.63µ ±   5%    34.35µ ±   2%  -13.31% (p=0.002 n=6)

                                 │     base.txt     │                 pr.txt                  │
                                 │       B/op       │      B/op       vs base                 │
Compare/osfs.boundOS_open-4         1032.0 ±   0%       424.0 ±   0%  -58.91% (p=0.002 n=6)
Compare/osfs.boundOS_read-4          0.000 ±   0%       0.000 ±   0%        ~ (p=1.000 n=6) ¹
Compare/osfs.boundOS_write-4        1507.0 ±   3%       261.0 ±   0%  -82.68% (p=0.002 n=6)
Compare/osfs.boundOS_create-4       1536.5 ±   3%       278.0 ±   1%  -81.91% (p=0.002 n=6)
Compare/osfs.boundOS_stat-4         1120.0 ±   0%       240.0 ±   0%  -78.57% (p=0.002 n=6)
Compare/osfs.boundOS_rename-4       4845.0 ±   0%       122.0 ±   1%  -97.48% (p=0.002 n=6)
Compare/osfs.boundOS_remove-4      1055.00 ±   0%       63.00 ±   0%  -94.03% (p=0.002 n=6)
Compare/osfs.boundOS_mkdirall-4     2123.5 ±  20%       199.0 ±   8%  -90.63% (p=0.002 n=6)
Compare/osfs.boundOS_tempfile-4      183.0 ±   1%       336.0 ±   0%  +83.61% (p=0.002 n=6)

                                 │    base.txt    │                 pr.txt                 │
                                 │   allocs/op    │  allocs/op    vs base                  │
Compare/osfs.boundOS_open-4        21.000 ±  0%      9.000 ±  0%   -57.14% (p=0.002 n=6)
Compare/osfs.boundOS_read-4         0.000 ±  0%      0.000 ±  0%         ~ (p=1.000 n=6) ¹
Compare/osfs.boundOS_write-4       25.000 ±  4%      8.000 ±  0%   -68.00% (p=0.002 n=6)
Compare/osfs.boundOS_create-4      26.000 ±  4%      8.000 ±  0%   -69.23% (p=0.002 n=6)
Compare/osfs.boundOS_stat-4        19.000 ±  0%      3.000 ±  0%   -84.21% (p=0.002 n=6)
Compare/osfs.boundOS_rename-4      68.000 ±  0%      8.000 ±  0%   -88.24% (p=0.002 n=6)
Compare/osfs.boundOS_remove-4      19.000 ±  0%      3.000 ±  0%   -84.21% (p=0.002 n=6)
Compare/osfs.boundOS_mkdirall-4    32.500 ± 14%      8.000 ± 12%   -75.38% (p=0.002 n=6)
Compare/osfs.boundOS_tempfile-4     6.000 ±  0%     14.000 ±  0%  +133.33% (p=0.002 n=6)
```

The default behaviour is for each operation to open and close a `os.Root`, which increases the cost per operation but still looks largely better than the previous implementation, with the exception of:

```
                                 │   base.txt    │                pr.txt                 │
                                 │    sec/op     │     sec/op      vs base               │
Compare/osfs.boundOS_open-4        16.48µ ±   1%    20.54µ ±   3%  +24.66% (p=0.002 n=6)
Compare/osfs.boundOS_stat-4        9.405µ ±   3%   12.629µ ±   6%  +34.29% (p=0.002 n=6)
Compare/osfs.boundOS_remove-4      30.58µ ±   3%    32.39µ ±   2%   +5.92% (p=0.002 n=6)

                                 │     base.txt     │                  pr.txt                  │
                                 │       B/op       │      B/op       vs base                  │
Compare/osfs.boundOS_tempfile-4      183.5 ±   0%       456.0 ±   0%  +148.50% (p=0.002 n=6)

                                 │    base.txt    │                 pr.txt                 │
                                 │   allocs/op    │  allocs/op    vs base                  │
Compare/osfs.boundOS_tempfile-4     6.000 ±  0%     18.000 ±  0%  +200.00% (p=0.002 n=6)
```

For a full break-down, refer to the [comment](https://github.com/go-git/go-billy/pull/158#issuecomment-3963108230) below.

A new `ErrPathEscapesParent` was introduced to represent when an operation is
attempting to escape the root/bound dir used for the bound OS.


Requires Go `1.25`.

Fixes https://github.com/go-git/go-billy/issues/135.
Relates to https://github.com/go-git/go-billy/issues/101.