### PR TITLE
osfs: Expose `Fd()` to enable mmap

### DIFF
--- a/helper/chroot/chroot_posix.go
+++ b/helper/chroot/chroot_posix.go
@@ -1,0 +1,19 @@
+//go:build !plan9 && !windows && !wasm
+
+package chroot
+
+type FileDescriptor interface {
+	Fd() (uintptr, bool)
+}
+
+// Fd exposes the underlying [os.File.Fd] func, which returns the
+// system file descriptor or handle referencing the open file.
+// If the underlying Filesystem does not expose this func,
+// the return will always be (0, false).
+func (f *file) Fd() (uintptr, bool) {
+	fd, ok := f.File.(FileDescriptor)
+	if ok {
+		return fd.Fd()
+	}
+	return 0, false
+}

--- a/osfs/os_posix.go
+++ b/osfs/os_posix.go
@@ -13,14 +13,14 @@ func (f *file) Lock() error {
 	f.m.Lock()
 	defer f.m.Unlock()
 
-	return unix.Flock(int(f.Fd()), unix.LOCK_EX)
+	return unix.Flock(int(f.File.Fd()), unix.LOCK_EX)
 }
 
 func (f *file) Unlock() error {
 	f.m.Lock()
 	defer f.m.Unlock()
 
-	return unix.Flock(int(f.Fd()), unix.LOCK_UN)
+	return unix.Flock(int(f.File.Fd()), unix.LOCK_UN)
 }
 
 func (f *file) Sync() error {
@@ -38,4 +38,10 @@ func umask(m int) func() {
 	return func() {
 		syscall.Umask(old)
 	}
+}
+
+// Fd exposes the underlying [os.File.Fd] func, which returns the
+// system file descriptor or handle referencing the open file.
+func (f *file) Fd() (uintptr, bool) {
+	return f.File.Fd(), true
 }


### PR DESCRIPTION
A new experimental go-git Object storage that leans on mmap for better performance and decreased memory churn is being worked on. In order to enable that work, relying on go-billy, the `Fd()` func needs to be exposed. This will be a posix focused implementation.