### PR TITLE
fix: bring os_js.go up to date with os.go

### DIFF
--- a/.github/workflows/test_js.yml
+++ b/.github/workflows/test_js.yml
@@ -1,0 +1,26 @@
+name: Test js/wasm
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+permissions: {}
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [oldstable, stable]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+    - name: Install Go
+      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Test
+      run: make jstest

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 # Go parameters
 GOCMD = go
-GOTEST = $(GOCMD) test 
+GOTEST = $(GOCMD) test
 WASIRUN_WRAPPER := $(CURDIR)/scripts/wasirun-wrapper
+JSWASM_WRAPPER := $(CURDIR)/scripts/jswasm-wrapper
 
 # Coverage
 COVERAGE_REPORT := coverage.out
@@ -30,6 +31,12 @@ wasitest: export GOARCH=wasm
 wasitest: export GOOS=wasip1
 wasitest:
 	$(GOTEST) -exec $(WASIRUN_WRAPPER) ./...
+
+.PHONY: jstest
+jstest: export GOARCH=wasm
+jstest: export GOOS=js
+jstest:
+	$(GOTEST) -exec $(JSWASM_WRAPPER) ./...
 
 validate: validate-lint validate-dirty ## Run validation checks.
 

--- a/osfs/os_js.go
+++ b/osfs/os_js.go
@@ -3,6 +3,9 @@
 package osfs
 
 import (
+	"path/filepath"
+	"strings"
+
 	"github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/helper/chroot"
 	"github.com/go-git/go-billy/v6/memfs"
@@ -16,8 +19,105 @@ var globalMemFs = memfs.New()
 var Default = memfs.New()
 
 // New returns a new OS filesystem.
-func New(baseDir string, _ ...Option) billy.Filesystem {
+// By default paths are deduplicated, but still enforced
+// under baseDir. For more info refer to WithDeduplicatePath.
+func New(baseDir string, opts ...Option) billy.Filesystem {
+	o := &options{
+		deduplicatePath: true,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	if o.Type == BoundOSFS {
+		return newBoundOS(baseDir, o.deduplicatePath)
+	}
+
+	return newChrootOS(baseDir)
+}
+
+func newChrootOS(baseDir string) billy.Filesystem {
 	return chroot.New(Default, Default.Join("/", baseDir))
 }
 
-type options struct{}
+// BoundOS is a fs implementation based on the js/wasm in-memory filesystem
+// which is bound to a base dir.
+type BoundOS struct {
+	billy.Filesystem
+	baseDir         string
+	deduplicatePath bool
+}
+
+func newBoundOS(d string, deduplicatePath bool) billy.Filesystem {
+	baseDir := globalMemFs.Join("/", d)
+	return &BoundOS{
+		Filesystem:      chroot.New(globalMemFs, baseDir),
+		baseDir:         baseDir,
+		deduplicatePath: deduplicatePath,
+	}
+}
+
+// Chroot returns a new BoundOS filesystem, with the base dir set to the
+// result of joining the provided path with the underlying base dir.
+func (fs *BoundOS) Chroot(path string) (billy.Filesystem, error) {
+	joined, err := fs.abs(path)
+	if err != nil {
+		return nil, err
+	}
+	return New(joined, WithBoundOS(), WithDeduplicatePath(fs.deduplicatePath)), nil
+}
+
+// Root returns the current base dir of the billy.Filesystem.
+func (fs *BoundOS) Root() string {
+	return fs.baseDir
+}
+
+func (fs *BoundOS) abs(filename string) (string, error) {
+	if filename == "." || filename == "" {
+		return fs.baseDir, nil
+	}
+
+	filename = filepath.ToSlash(filename)
+	filename = filepath.Clean(filename)
+	if strings.HasPrefix(filename, "..") {
+		return "", billy.ErrCrossedBoundary
+	}
+
+	filename = strings.TrimPrefix(filename, string(filepath.Separator))
+	return filepath.Clean(filepath.Join(fs.baseDir, filepath.FromSlash(filename))), nil
+}
+
+// WithBoundOS returns the option of using a Bound filesystem OS.
+func WithBoundOS() Option {
+	return func(o *options) {
+		o.Type = BoundOSFS
+	}
+}
+
+// WithChrootOS returns the option of using a Chroot filesystem OS.
+func WithChrootOS() Option {
+	return func(o *options) {
+		o.Type = ChrootOSFS
+	}
+}
+
+// WithDeduplicatePath toggles the deduplication of the base dir in the path.
+// This option is accepted for API parity with non-js builds and has no effect
+// on the js/wasm in-memory implementation.
+func WithDeduplicatePath(enabled bool) Option {
+	return func(o *options) {
+		o.deduplicatePath = enabled
+	}
+}
+
+type options struct {
+	Type
+	deduplicatePath bool
+}
+
+type Type int
+
+const (
+	ChrootOSFS Type = iota
+	BoundOSFS
+)

--- a/osfs/os_js_test.go
+++ b/osfs/os_js_test.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/helper/chroot"
+	"github.com/go-git/go-billy/v6/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenDoesNotCreateDir(t *testing.T) {
@@ -41,5 +43,76 @@ func TestDefault(t *testing.T) {
 	}
 }
 
-// API call assertions
+func TestWithBoundOSReturnsBoundOS(t *testing.T) {
+	got := New(t.TempDir(), WithBoundOS())
+	assert.IsType(t, &BoundOS{}, got)
+}
+
+func TestWithChrootOSReturnsChrootHelper(t *testing.T) {
+	got := New(t.TempDir(), WithChrootOS())
+	assert.IsType(t, &chroot.ChrootHelper{}, got)
+}
+
+func TestDefaultTypeIsChrootOSFS(t *testing.T) {
+	got := New(t.TempDir())
+	assert.IsType(t, &chroot.ChrootHelper{}, got)
+}
+
+func TestBoundOSRoot(t *testing.T) {
+	dir := t.TempDir()
+	fs := New(dir, WithBoundOS()).(*BoundOS)
+	assert.Equal(t, filepath.Join("/", dir), fs.Root())
+}
+
+func TestBoundOSReadWrite(t *testing.T) {
+	fs := New(t.TempDir(), WithBoundOS())
+
+	err := util.WriteFile(fs, "hello.txt", []byte("world"), 0o600)
+	require.NoError(t, err)
+
+	got, err := util.ReadFile(fs, "hello.txt")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("world"), got)
+}
+
+func TestBoundOSChrootScopesPaths(t *testing.T) {
+	fs := New(t.TempDir(), WithBoundOS())
+
+	sub, err := fs.Chroot("sub")
+	require.NoError(t, err)
+	assert.IsType(t, &BoundOS{}, sub)
+
+	err = util.WriteFile(sub, "in-sub.txt", []byte("scoped"), 0o600)
+	require.NoError(t, err)
+
+	got, err := util.ReadFile(fs, filepath.Join("sub", "in-sub.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("scoped"), got)
+}
+
+func TestBoundOSRejectsParentTraversal(t *testing.T) {
+	fs := New(t.TempDir(), WithBoundOS()).(*BoundOS)
+	_, err := fs.Chroot("..")
+	assert.ErrorIs(t, err, billy.ErrCrossedBoundary)
+}
+
+func TestWithDeduplicatePathIsAccepted(t *testing.T) {
+	// WithDeduplicatePath has no effect on the in-memory js/wasm
+	// implementation, but must remain callable for API parity with the
+	// non-js build so go-git and other consumers compile unchanged.
+	fs := New(t.TempDir(), WithBoundOS(), WithDeduplicatePath(false))
+	assert.IsType(t, &BoundOS{}, fs)
+}
+
+// API call assertions. These ensure the exported option constructors remain
+// available under GOOS=js so downstream code (e.g. go-git) keeps compiling.
 var _ = New("/")
+var _ = New("/", WithBoundOS())
+var _ = New("/", WithChrootOS())
+var _ = New("/", WithDeduplicatePath(false))
+
+// Type constants must stay exported for any consumer that switches on them.
+var (
+	_ Type = ChrootOSFS
+	_ Type = BoundOSFS
+)

--- a/scripts/jswasm-wrapper
+++ b/scripts/jswasm-wrapper
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Wrapper script for go_js_wasm_exec to be executable by go test -exec.
+#
+# Prefers the Go toolchain's bundled Node.js launcher over any other
+# go_js_wasm_exec that may be present in PATH (e.g. wasmbrowsertest),
+# which ensures CI runs tests in Node.js rather than a headless browser.
+#
+
+set -e
+
+GOROOT=$(go env GOROOT)
+for candidate in \
+	"${GOROOT}/lib/wasm/go_js_wasm_exec" \
+	"${GOROOT}/misc/wasm/go_js_wasm_exec"; do
+	if [ -x "${candidate}" ]; then
+		exec "${candidate}" "$@"
+	fi
+done
+
+echo "jswasm-wrapper: could not find go_js_wasm_exec in GOROOT/lib/wasm or GOROOT/misc/wasm" >&2
+exit 1


### PR DESCRIPTION
Recent changes to os_js.go added WithBoundOS and ChrootOSFS.

These changes were not propagated to os_js.go, which results in the following build failures in go-git:

```
% GOOS=js GOARCH=wasm gb ./...
github.com/go-git/go-git/v6
./remote.go:214:32: undefined: osfs.WithBoundOS
./repository.go:348:29: undefined: osfs.WithBoundOS ./repository.go:353:28: undefined: osfs.WithBoundOS ./repository.go:460:28: undefined: osfs.WithBoundOS ./repository.go:468:44: undefined: osfs.WithBoundOS ./repository.go:528:32: undefined: osfs.WithBoundOS ./repository.go:531:46: undefined: osfs.WithBoundOS ./repository.go:551:36: undefined: osfs.WithBoundOS ./repository.go:553:62: undefined: osfs.WithBoundOS
```

This commit brings os_js.go up to date with os.go to fix this.

All tests pass with GOOS=js GOARCH=wasm now.