### PR TITLE
Cherry pick of go-git/go-billy#195 into v5

### DIFF
--- a/helper/iofs/iofs.go
+++ b/helper/iofs/iofs.go
@@ -5,7 +5,6 @@ package iofs
 import (
 	"io"
 	"io/fs"
-	"path/filepath"
 
 	billyfs "github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/helper/polyfill"
@@ -45,7 +44,7 @@ var _ fs.ReadFileFS = (*adapterFs)(nil)
 
 // Open opens the named file on the underlying FS, implementing fs.FS (returning a file or error).
 func (a *adapterFs) Open(name string) (fs.File, error) {
-	if name[0] == '/' || name != filepath.Clean(name) {
+	if !fs.ValidPath(name) {
 		// fstest.TestFS explicitly checks that these should return error.
 		// MemFS performs the clean internally, so we need to block that here for testing purposes.
 		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}

--- a/helper/iofs/iofs.go
+++ b/helper/iofs/iofs.go
@@ -5,6 +5,7 @@ package iofs
 import (
 	"io"
 	"io/fs"
+	"strings"
 
 	billyfs "github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/helper/polyfill"
@@ -42,9 +43,16 @@ var _ fs.ReadFileFS = (*adapterFs)(nil)
 
 // TODO: implement fs.GlobFS, which will be a fair bit more code.
 
+// validPath checks that name is a valid io/fs path. In addition to the
+// standard fs.ValidPath checks, it rejects backslashes which on Windows
+// would be interpreted as path separators by the underlying billy filesystem.
+func validPath(name string) bool {
+	return fs.ValidPath(name) && !strings.Contains(name, `\`)
+}
+
 // Open opens the named file on the underlying FS, implementing fs.FS (returning a file or error).
 func (a *adapterFs) Open(name string) (fs.File, error) {
-	if !fs.ValidPath(name) {
+	if !validPath(name) {
 		// fstest.TestFS explicitly checks that these should return error.
 		// MemFS performs the clean internally, so we need to block that here for testing purposes.
 		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
@@ -66,6 +74,9 @@ func (a *adapterFs) Open(name string) (fs.File, error) {
 
 // ReadDir reads the named directory, implementing fs.ReadDirFS (returning a listing or error).
 func (a *adapterFs) ReadDir(name string) ([]fs.DirEntry, error) {
+	if !validPath(name) {
+		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrInvalid}
+	}
 	items, err := a.fs.ReadDir(name)
 	if err != nil {
 		return nil, err
@@ -79,11 +90,17 @@ func (a *adapterFs) ReadDir(name string) ([]fs.DirEntry, error) {
 
 // Stat returns information on the named file, implementing fs.StatFS (returning FileInfo or error).
 func (a *adapterFs) Stat(name string) (fs.FileInfo, error) {
+	if !validPath(name) {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrInvalid}
+	}
 	return a.fs.Stat(name)
 }
 
 // ReadFile reads the named file and returns its contents, implementing fs.ReadFileFS (returning contents or error).
 func (a *adapterFs) ReadFile(name string) ([]byte, error) {
+	if !validPath(name) {
+		return nil, &fs.PathError{Op: "readfile", Path: name, Err: fs.ErrInvalid}
+	}
 	stat, err := a.fs.Stat(name)
 	if err != nil {
 		return nil, err

--- a/helper/iofs/iofs_test.go
+++ b/helper/iofs/iofs_test.go
@@ -11,6 +11,7 @@ import (
 
 	billyfs "github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/stretchr/testify/require"
 )
 
 type errorList interface {
@@ -28,9 +29,9 @@ func TestWithFSTest(t *testing.T) {
 	iofs := New(memfs)
 
 	files := map[string]string{
-		"foo.txt":                       "hello, world",
-		"bar.txt":                       "goodbye, world",
-		filepath.Join("dir", "baz.txt"): "こんにちわ, world",
+		"foo.txt":     "hello, world",
+		"bar.txt":     "goodbye, world",
+		"dir/baz.txt": "こんにちわ, world",
 	}
 	created_files := make([]string, 0, len(files))
 	for filename, contents := range files {
@@ -38,13 +39,45 @@ func TestWithFSTest(t *testing.T) {
 		created_files = append(created_files, filename)
 	}
 
-	if runtime.GOOS == "windows" {
-		t.Skip("fstest.TestFS is not yet windows path aware")
-	}
-
 	err := fstest.TestFS(iofs, created_files...)
 	if err != nil {
 		checkFsTestError(t, err, files)
+	}
+}
+
+// TestOpenForwardSlashPath verifies that Open works with forward-slash paths
+// on all platforms. This is a regression test ensuring filepath.Clean is not
+// used when cleaning paths in Open() (it should use path.Clean) so valid
+// fs.FS paths like "dir/file.txt" are not rejected on Windows.
+func TestOpenForwardSlashPath(t *testing.T) {
+	t.Parallel()
+	mem := memfs.New()
+	adapter := New(mem)
+
+	makeFile(mem, t, "dir/subdir/file.txt", "content")
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{"simple-nested", "dir/subdir/file.txt", false},
+		{"directory", "dir/subdir", false},
+		{"dot-path", ".", false},
+		{"absolute-path-rejected", "/dir/subdir/file.txt", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			f, err := adapter.Open(tt.path)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NoError(t, f.Close())
+		})
 	}
 }
 


### PR DESCRIPTION
This is a cherry pick of https://github.com/go-git/go-billy/pull/195 into the v5 release branch.

I believe this to be a candidate as per the [contribution guidelines](https://github.com/go-git/go-billy?tab=contributing-ov-file#:~:text=we%20will%20only%20be%20accepting%20bug%20fixes%20or%20CVE%20related%20dependency%20bumps%20for%20the%20v5%20release), this backport is fixes a critical bug breaking the iofs adatper on windows.