### PR TITLE
v5: osfs: ChrootOS eval baseDir on creation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.24.x, oldstable, stable]
+        go-version: [oldstable, stable]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/test_wasip1.yml
+++ b/.github/workflows/test_wasip1.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.22.x,1.23.x]
+        go-version: [oldstable, stable]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,5 @@
 module github.com/go-git/go-billy/v5
 
-// go-git supports the last 3 stable Go versions.
 go 1.25.0
 
 require (

--- a/osfs/os_chroot.go
+++ b/osfs/os_chroot.go
@@ -26,6 +26,10 @@ import (
 type ChrootOS struct{}
 
 func newChrootOS(baseDir string) billy.Filesystem {
+	if resolved, err := filepath.EvalSymlinks(baseDir); err == nil {
+		baseDir = resolved
+	}
+
 	return chroot.New(&ChrootOS{}, baseDir)
 }
 

--- a/osfs/os_chroot_test.go
+++ b/osfs/os_chroot_test.go
@@ -51,6 +51,27 @@ func (s *ChrootOSSuite) TestOpenDoesNotCreateDir(c *C) {
 	c.Assert(os.IsNotExist(err), Equals, true)
 }
 
+func (s *ChrootOSSuite) TestSymlinkedRoot(c *C) {
+	root := c.MkDir()
+	realRoot := filepath.Join(root, "real")
+	linkRoot := filepath.Join(root, "link")
+
+	c.Assert(os.Mkdir(realRoot, 0755), IsNil)
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		c.Skip("symlink creation is not supported")
+	}
+
+	fs := newChrootOS(linkRoot)
+
+	fi, err := fs.Stat("/")
+	c.Assert(err, IsNil)
+	c.Assert(fi.IsDir(), Equals, true)
+
+	_, err = fs.Stat(".git")
+	c.Assert(os.IsNotExist(err), Equals, true)
+	c.Assert(err, Not(Equals), billy.ErrCrossedBoundary)
+}
+
 func (s *ChrootOSSuite) TestCapabilities(c *C) {
 	_, ok := s.FS.(billy.Capable)
 	c.Assert(ok, Equals, true)


### PR DESCRIPTION
Fixes a regression added by #203 that would return `chroot boundary crossed` when a temporary dir was used in MacOS.