### PR TITLE
Implement io.ReaderAt and io.Seeker for iofs adapter

### DIFF
--- a/helper/iofs/iofs.go
+++ b/helper/iofs/iofs.go
@@ -92,6 +92,10 @@ type adapterFile struct {
 
 var _ fs.File = (*adapterFile)(nil)
 
+var _ io.ReaderAt = (*adapterFile)(nil)
+
+var _ io.Seeker = (*adapterFile)(nil)
+
 // Close closes the file, implementing fs.File (and io.Closer).
 func (a *adapterFile) Close() error {
 	return a.file.Close()
@@ -100,6 +104,14 @@ func (a *adapterFile) Close() error {
 // Read reads bytes from the file, implementing fs.File (and io.Reader).
 func (a *adapterFile) Read(b []byte) (int, error) {
 	return a.file.Read(b)
+}
+
+func (a *adapterFile) ReadAt(p []byte, off int64) (int, error) {
+	return a.file.ReadAt(p, off)
+}
+
+func (a *adapterFile) Seek(offset int64, whence int) (int64, error) {
+	return a.file.Seek(offset, whence)
 }
 
 // Stat returns file information, implementing fs.File (returning FileInfo or error).

--- a/helper/iofs/iofs_test.go
+++ b/helper/iofs/iofs_test.go
@@ -2,6 +2,7 @@ package iofs
 
 import (
 	"errors"
+	"io"
 	"io/fs"
 	"path/filepath"
 	"runtime"
@@ -72,6 +73,8 @@ func TestOpenForwardSlashPath(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+			require.Implements(t, (*io.ReaderAt)(nil), f)
+			require.Implements(t, (*io.Seeker)(nil), f)
 			require.NoError(t, f.Close())
 		})
 	}


### PR DESCRIPTION
Per \[`io.fs/File` documentation](https://pkg.go.dev/io/fs#File):



> A file may implement io.ReaderAt or io.Seeker as optimizations.



I'm trying to use `go-billy` to present a virtual filesystem to https://github.com/google/osv-scalibr, and (one!) of the plugins attempts to use `io.ReaderAt` and fails otherwise.  Since this is just a matter of plumbing, I added the methods as pass-throughs.

