### PR TITLE
osfs: Fix infinite recursion in abs with empty baseDir

### DIFF
--- a/osfs/os_bound.go
+++ b/osfs/os_bound.go
@@ -409,7 +409,7 @@ func (fs *BoundOS) abs(filename string) (string, error) {
 		return "", err
 	}
 
-	if fs.deduplicatePath {
+	if fs.deduplicatePath && fs.baseDir != "" {
 		vol := filepath.VolumeName(fs.baseDir)
 		dup := filepath.Join(fs.baseDir, fs.baseDir[len(vol):])
 		if strings.HasPrefix(path, dup+string(filepath.Separator)) {

--- a/osfs/os_bound_test.go
+++ b/osfs/os_bound_test.go
@@ -1560,7 +1560,7 @@ func TestAbsEmptyBaseDir(t *testing.T) {
 	got, err := fs.abs(filepath.FromSlash("/tmp"))
 	require.NoError(t, err)
 
-	want, err := securejoin.SecureJoin("", filepath.FromSlash("/tmp"))
+	want, err := fs.secureJoin(filepath.FromSlash("/tmp"))
 	require.NoError(t, err)
 	assert.Equal(t, want, got)
 }

--- a/osfs/os_bound_test.go
+++ b/osfs/os_bound_test.go
@@ -1553,6 +1553,18 @@ func TestAbs(t *testing.T) {
 	}
 }
 
+func TestAbsEmptyBaseDir(t *testing.T) {
+	fs, ok := newBoundOS("", true).(*BoundOS)
+	require.True(t, ok)
+
+	got, err := fs.abs(filepath.FromSlash("/tmp"))
+	require.NoError(t, err)
+
+	want, err := securejoin.SecureJoin("", filepath.FromSlash("/tmp"))
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
 func TestAbsReturnsSecureJoinError(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink creation requires additional privileges on windows")


### PR DESCRIPTION
When `baseDir` is empty and `deduplicatePath` is enabled, the dedup prefix collapses to `""` so `strings.HasPrefix(path, "/")` matches any absolute path and `abs` recurses on the same input until the stack overflows.

Skip deduplication when there is no `baseDir` to deduplicate. `absNoFollow` already has the equivalent guard.

Fixes #209