### PR TITLE
osfs: sort ReadDir output by filename

### DIFF
--- a/osfs/os_rootfs.go
+++ b/osfs/os_rootfs.go
@@ -3,11 +3,13 @@
 package osfs
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	gofs "io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/go-git/go-billy/v6"
@@ -142,6 +144,9 @@ func (fs *RootOS) ReadDir(name string) ([]gofs.DirEntry, error) {
 	if err != nil {
 		return nil, translateError(err, rel)
 	}
+	slices.SortFunc(e, func(a, b gofs.DirEntry) int {
+		return cmp.Compare(a.Name(), b.Name())
+	})
 	return e, nil
 }
 

--- a/osfs/os_test.go
+++ b/osfs/os_test.go
@@ -8,6 +8,33 @@ import (
 	"testing"
 )
 
+func TestReadDirFilesystem(t *testing.T) {
+	fs := New(t.TempDir())
+
+	for _, name := range []string{"file1.txt", "file3.txt", "file2.txt"} {
+		f, err := fs.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		f.Close()
+	}
+
+	entries, err := fs.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+
+	want := []string{"file1.txt", "file2.txt", "file3.txt"}
+	for i, e := range entries {
+		if e.Name() != want[i] {
+			t.Fatalf("expected %s at index %d, got %s", want[i], i, e.Name())
+		}
+	}
+}
+
 var _ fs.File = &file{}
 
 func TestDefault(t *testing.T) {


### PR DESCRIPTION
The Dir interface contract requires ReadDir to return entries sorted
by filename. Both RootOS.ReadDir and BoundOS.ReadDir now fulfill this
by sorting with slices.SortFunc + cmp.Compare in RootOS.ReadDir, with
BoundOS.ReadDir delegating to it.

closes #221
