### PR TITLE
osfs: mmap, use AddCleanup instead of finalizer and add test

### DIFF
--- a/osfs/mmap_file.go
+++ b/osfs/mmap_file.go
@@ -34,6 +34,12 @@ type mmapFile struct {
 	cleanup runtime.Cleanup
 }
 
+// mmapResources holds the resorces to be cleaned up when mmapFile is GC.
+type mmapResources struct {
+	data []byte
+	file *os.File
+}
+
 // newMmapFile maps f read-only and returns an [*mmapFile] that owns
 // f. On success the returned handle is responsible for closing the
 // underlying [*os.File] via [(*mmapFile).Close].
@@ -71,11 +77,15 @@ func newMmapFile(f *os.File, name string) (*mmapFile, error) {
 
 	// unmap and close the file when the mmapFile is garbage collected and no
 	// Close is called before.
-	closeFunc := func(_ struct{}) {
-		_ = unix.Munmap(data)
-		_ = f.Close()
+	mr := mmapResources{
+		data: data,
+		file: f,
 	}
-	m.cleanup = runtime.AddCleanup(m, closeFunc, struct{}{})
+	closeFunc := func(res mmapResources) {
+		_ = unix.Munmap(res.data)
+		_ = res.file.Close()
+	}
+	m.cleanup = runtime.AddCleanup(m, closeFunc, mr)
 
 	return m, nil
 }

--- a/osfs/mmap_file.go
+++ b/osfs/mmap_file.go
@@ -68,10 +68,15 @@ func newMmapFile(f *os.File, name string) (*mmapFile, error) {
 	}
 
 	m := &mmapFile{f: f, data: data, name: name}
-	// Belt and braces for callers that forget to Close: the runtime
-	// will munmap and close the fd when m becomes unreachable. Close
-	// clears this finalizer on the orderly path.
-	m.cleanup = runtime.AddCleanup(m, mmapClean, data)
+
+	// unmap and close the file when the mmapFile is garbage collected and no
+	// Close is called before.
+	closeFunc := func(_ struct{}) {
+		_ = unix.Munmap(data)
+		_ = f.Close()
+	}
+	m.cleanup = runtime.AddCleanup(m, closeFunc, struct{}{})
+
 	return m, nil
 }
 
@@ -176,8 +181,4 @@ func (m *mmapFile) Close() error {
 	m.data = nil
 	closeErr := m.f.Close()
 	return errors.Join(munmapErr, closeErr)
-}
-
-func mmapClean(d []byte) {
-	_ = unix.Munmap(d)
 }

--- a/osfs/mmap_file.go
+++ b/osfs/mmap_file.go
@@ -30,6 +30,8 @@ type mmapFile struct {
 	mu     sync.RWMutex
 	cursor int64
 	closed bool
+
+	cleanup runtime.Cleanup
 }
 
 // newMmapFile maps f read-only and returns an [*mmapFile] that owns
@@ -69,7 +71,7 @@ func newMmapFile(f *os.File, name string) (*mmapFile, error) {
 	// Belt and braces for callers that forget to Close: the runtime
 	// will munmap and close the fd when m becomes unreachable. Close
 	// clears this finalizer on the orderly path.
-	runtime.SetFinalizer(m, (*mmapFile).Close)
+	m.cleanup = runtime.AddCleanup(m, mmapClean, data)
 	return m, nil
 }
 
@@ -168,10 +170,14 @@ func (m *mmapFile) Close() error {
 		return os.ErrClosed
 	}
 	m.closed = true
-	runtime.SetFinalizer(m, nil)
+	m.cleanup.Stop()
 
 	munmapErr := unix.Munmap(m.data)
 	m.data = nil
 	closeErr := m.f.Close()
 	return errors.Join(munmapErr, closeErr)
+}
+
+func mmapClean(d []byte) {
+	_ = unix.Munmap(d)
 }

--- a/osfs/mmap_file_cleanup_test.go
+++ b/osfs/mmap_file_cleanup_test.go
@@ -1,0 +1,62 @@
+//go:build linux
+
+package osfs
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootOSMmapCleanup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data")
+	_ = writePattern(t, path, 64*1024)
+
+	fs := newTestBoundOS(t, dir, WithMmap())
+	f, err := fs.Open("data")
+	require.NoError(t, err)
+
+	ok, err := isFileMapped(path)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	_ = f.Name()
+	f = nil
+	_ = f
+
+	runtime.GC()
+
+	ok, err = isFileMapped(path)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+// isFileMapped checks if a path appears in the proc maps file. Only tested
+// in Linux.
+func isFileMapped(path string) (bool, error) {
+	pid := os.Getpid()
+
+	mapsPath := fmt.Sprintf("/proc/%d/maps", pid)
+	f, err := os.Open(mapsPath)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		l := s.Text()
+		if strings.Contains(l, path) {
+			return true, nil
+		}
+	}
+
+	return false, s.Err()
+}

--- a/osfs/mmap_file_cleanup_test.go
+++ b/osfs/mmap_file_cleanup_test.go
@@ -31,7 +31,15 @@ func TestRootOSMmapCleanup(t *testing.T) {
 	f = nil
 	_ = f
 
-	runtime.GC()
+	for range 10 {
+		runtime.GC()
+
+		ok, err = isFileMapped(path)
+		require.NoError(t, err)
+		if !ok {
+			break
+		}
+	}
 
 	ok, err = isFileMapped(path)
 	require.NoError(t, err)


### PR DESCRIPTION
Since go 1.24 it seems that the preferred way to cleanup after GC is `runtime.AddCleanup`. The change does basically the same. It's even quite the same case as the example in the go blog introducing this function: https://go.dev/blog/cleanups-and-weak

I've also added a test for Linux that checks that the finalizer/cleanup works (works with the two versions) so at least we are sure we have not misplaced the finalizer. The test is in a separate commit in case you are not interested in the `AddCleanup` change.

This odd dance with variables was done to not trigger the linter as after cleaning `f` we don't do anything with it.

```go
	_ = f.Name()
	f = nil
	_ = f
```

I've found that cleaning the variable is not needed as the compiler is smart enough to know that `f` is not used anymore after `f.Name()` and `runtime.GC` triggers the finalizer. I just wanted to be explicit.