### PR TITLE
osfs: expose zero-copy access to memory-mapped files

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -215,9 +215,13 @@ type Syncer interface {
 // The returned slices are valid only until the File is Closed and MUST NOT be
 // mutated — the mapping is read-only and shared.
 type Mmap interface {
-	// Bytes returns the entire mapping.
+	// Bytes returns the entire mapping. The returned slice is valid only until
+	// Close and must not be mutated — the mapping is read-only and shared.
 	Bytes() []byte
-	// Slice returns a zero-copy sub-window [off, off+length).
+	// Slice returns a zero-copy sub-window [off, off+length). off and off+length
+	// must lie within [0, len(Bytes())]; out-of-range values panic. The returned
+	// slice is valid only until Close and must not be mutated — the mapping is
+	// read-only and shared.
 	Slice(off, length int64) []byte
 }
 

--- a/fs.go
+++ b/fs.go
@@ -36,6 +36,11 @@ const (
 	LockCapability
 	// SyncCapability is the ability to synchronize file contents to stable storage.
 	SyncCapability
+	// MmapCapability advertises that the filesystem MAY return read-only
+	// memory-mapped files (see the Mmap interface). Advisory only: mmap is
+	// decided per-open (read-only flag, platform, file size), so the reliable
+	// signal is a billy.Mmap type assertion on the returned File.
+	MmapCapability
 
 	// DefaultCapabilities lists all capable features supported by filesystems
 	// without Capability interface. This list should not be changed until a
@@ -203,6 +208,17 @@ type Locker interface {
 type Syncer interface {
 	// Sync commits the current contents of the file to stable storage.
 	Sync() error
+}
+
+// Mmap is implemented by a File backed by a read-only memory mapping. It
+// exposes zero-copy access to the mapped bytes. Detected via type assertion.
+// The returned slices are valid only until the File is Closed and MUST NOT be
+// mutated — the mapping is read-only and shared.
+type Mmap interface {
+	// Bytes returns the entire mapping.
+	Bytes() []byte
+	// Slice returns a zero-copy sub-window [off, off+length).
+	Slice(off, length int64) []byte
 }
 
 // Capable interface can return the available features of a filesystem.

--- a/fs_test.go
+++ b/fs_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/go-git/go-billy/v6" //nolint
 	"github.com/go-git/go-billy/v6/internal/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCapabilities(t *testing.T) {
@@ -31,3 +32,23 @@ func TestCapabilities(t *testing.T) {
 	dummy := new(test.BasicMock)
 	assert.Equal(t, Capabilities(dummy), DefaultCapabilities)
 }
+
+func TestMmapCapabilityIsDistinctBit(t *testing.T) {
+	// MmapCapability must be its own bit, not overlapping any existing one,
+	// and must NOT be part of DefaultCapabilities (it is platform/config gated).
+	all := WriteCapability | ReadCapability | ReadAndWriteCapability |
+		SeekCapability | TruncateCapability | LockCapability |
+		SyncCapability
+	require.Zero(t, all&MmapCapability, "MmapCapability overlaps an existing bit")
+	require.Zero(t, DefaultCapabilities&MmapCapability,
+		"MmapCapability must not be a default capability")
+}
+
+func TestMmapInterfaceShape(t *testing.T) {
+	var _ Mmap = mmapStub{}
+}
+
+type mmapStub struct{}
+
+func (mmapStub) Bytes() []byte                  { return nil }
+func (mmapStub) Slice(off, length int64) []byte { return nil }

--- a/osfs/mmap_file.go
+++ b/osfs/mmap_file.go
@@ -178,6 +178,31 @@ func (m *mmapFile) Truncate(size int64) error {
 	return &os.PathError{Op: "truncate", Path: m.name, Err: os.ErrPermission}
 }
 
+// Bytes returns the entire mapping. The returned slice is valid only until
+// Close and must not be mutated — the mapping is read-only and shared.
+// Returns nil after Close.
+func (m *mmapFile) Bytes() []byte {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.closed {
+		return nil
+	}
+	return m.data
+}
+
+// Slice returns a zero-copy sub-window [off, off+length). off and off+length
+// must lie within [0, len(Bytes())]; out-of-range values panic. The returned
+// slice is valid only until Close and must not be mutated — the mapping is
+// read-only and shared. Returns nil after Close.
+func (m *mmapFile) Slice(off, length int64) []byte {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.closed {
+		return nil
+	}
+	return m.data[off : off+length]
+}
+
 func (m *mmapFile) Close() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/osfs/mmap_file_assert_test.go
+++ b/osfs/mmap_file_assert_test.go
@@ -15,6 +15,9 @@ func assertMmapBackingWhenAvailable(t *testing.T, f billy.File) {
 	require.True(t, ok, "WithMmap should select *mmapFile on this platform, got %T", f)
 }
 
-// Ensure *mmapFile satisfies billy.File at compile-time on platforms
-// where it has a real implementation.
-var _ billy.File = (*mmapFile)(nil)
+// Ensure *mmapFile satisfies billy.File and billy.Mmap at compile-time on
+// platforms where it has a real implementation.
+var (
+	_ billy.File = (*mmapFile)(nil)
+	_ billy.Mmap = (*mmapFile)(nil)
+)

--- a/osfs/mmap_file_other.go
+++ b/osfs/mmap_file_other.go
@@ -26,3 +26,5 @@ func (m *mmapFile) WriteAt(p []byte, off int64) (int, error)      { return 0, os
 func (m *mmapFile) Seek(offset int64, whence int) (int64, error)  { return 0, os.ErrInvalid }
 func (m *mmapFile) Truncate(size int64) error                     { return os.ErrInvalid }
 func (m *mmapFile) Close() error                                  { return os.ErrInvalid }
+func (m *mmapFile) Bytes() []byte                                 { return nil }
+func (m *mmapFile) Slice(off, length int64) []byte                { return nil }

--- a/osfs/mmap_file_test.go
+++ b/osfs/mmap_file_test.go
@@ -377,3 +377,23 @@ func TestOpenBackingSelection(t *testing.T) {
 // Ensure *file satisfies billy.File at compile-time so type
 // assertions in tests are guaranteed valid.
 var _ billy.File = (*file)(nil)
+
+func TestMmapFilesystemAdvertisesCapability(t *testing.T) {
+	t.Parallel()
+
+	osRoot, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = osRoot.Close() })
+
+	root, err := FromRoot(osRoot, WithMmap())
+	require.NoError(t, err)
+	require.NotZero(t, root.Capabilities()&billy.MmapCapability)
+
+	plain, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = plain.Close() })
+
+	plainFS, err := FromRoot(plain)
+	require.NoError(t, err)
+	require.Zero(t, plainFS.Capabilities()&billy.MmapCapability)
+}

--- a/osfs/mmap_file_zerocopy_test.go
+++ b/osfs/mmap_file_zerocopy_test.go
@@ -1,0 +1,37 @@
+//go:build darwin || linux
+
+package osfs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-billy/v6"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMmapFileZeroCopy(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	name := filepath.Join(dir, "data.bin")
+	want := []byte("the quick brown fox")
+	require.NoError(t, os.WriteFile(name, want, 0o600))
+
+	osRoot, err := os.OpenRoot(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = osRoot.Close() })
+
+	root, err := FromRoot(osRoot, WithMmap())
+	require.NoError(t, err)
+
+	f, err := root.Open("data.bin")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+
+	m, ok := f.(billy.Mmap)
+	require.True(t, ok, "mmap-backed file must satisfy billy.Mmap")
+	require.Equal(t, want, m.Bytes())
+	require.Equal(t, []byte("quick"), m.Slice(4, 5))
+}

--- a/osfs/os_bound.go
+++ b/osfs/os_bound.go
@@ -84,7 +84,11 @@ func (fs *BoundOS) rootFSWithCreate(name string, createBase bool) (*RootOS, func
 }
 
 func (fs *BoundOS) Capabilities() billy.Capability {
-	return boundCapabilities()
+	c := boundCapabilities()
+	if fs.mmap {
+		c |= billy.MmapCapability
+	}
+	return c
 }
 
 func (fs *BoundOS) Create(name string) (billy.File, error) {

--- a/osfs/os_rootfs.go
+++ b/osfs/os_rootfs.go
@@ -57,7 +57,11 @@ type RootOS struct {
 }
 
 func (fs *RootOS) Capabilities() billy.Capability {
-	return boundCapabilities()
+	c := boundCapabilities()
+	if fs.mmap {
+		c |= billy.MmapCapability
+	}
+	return c
 }
 
 func (fs *RootOS) Create(name string) (billy.File, error) {


### PR DESCRIPTION
Adds a small optional-interface API for reading memory-mapped files
without copying:

- `billy.Mmap` — an optional interface (`Bytes() []byte`,
  `Slice(off, length int64) []byte`) that a `File` may implement when it
  is backed by a read-only memory mapping. Detected via type assertion,
  the same pattern as `billy.Locker` / `billy.Syncer`.
- `billy.MmapCapability` — a new capability bit (appended after
  `SyncCapability`, so no existing bit value shifts) advertising that a
  filesystem *may* hand out mmap-backed files. Advisory only; the
  reliable signal is a `billy.Mmap` type assertion on the returned file.
- `osfs.mmapFile` implements `Bytes()`/`Slice()` (RLock-guarded, `nil`
  after `Close`, consistent with the existing `ReadAt`), and
  `RootOS`/`BoundOS` advertise `MmapCapability` when constructed with
  `WithMmap()`.

## Why

Consumers that memory-map large read-only files (packfiles, indexes,
bitmaps) want to parse structured regions directly out of the mapping
instead of issuing a `ReadAt` copy per field. Today an mmap-backed
`osfs` file is transparent — a caller cannot obtain the underlying bytes
or even detect that it is mmap-backed. This exposes zero-copy access
behind a narrow, opt-in interface without changing the default `File`
contract.

## Notes

- Additive and backward compatible: `MmapCapability` is not part of
  `DefaultCapabilities`/`AllCapabilities`, and the new interface is
  optional.
- The returned slices are valid only until the file is `Close`d and must
  not be mutated — the mapping is read-only and shared. Out-of-range
  `Slice` args panic (documented precondition), matching the zero-copy
  intent. Callers keep the mapping alive for the slice's lifetime.
- mmap is linux/darwin only; the non-mmap platform stub implements the
  interface returning `nil`, and non-mmap `Capabilities()` are unchanged.