### PR TITLE
Keep the seek offset out of memfs WriteAt

### DIFF
--- a/memfs/file.go
+++ b/memfs/file.go
@@ -68,7 +68,10 @@ func (f *file) Seek(offset int64, whence int) (int64, error) {
 }
 
 func (f *file) Write(p []byte) (int, error) {
-	return f.WriteAt(p, f.position)
+	n, err := f.WriteAt(p, f.position)
+	f.position += int64(n)
+
+	return n, err
 }
 
 func (f *file) WriteAt(p []byte, off int64) (int, error) {
@@ -80,10 +83,8 @@ func (f *file) WriteAt(p []byte, off int64) (int, error) {
 		return 0, errors.New("write not supported")
 	}
 
-	n, err := f.content.WriteAt(p, off)
-	f.position = off + int64(n)
-
-	return n, err
+	// io.WriterAt: WriteAt must not move the seek offset.
+	return f.content.WriteAt(p, off)
 }
 
 func (f *file) Close() error {

--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -813,3 +813,32 @@ func TestTruncate(t *testing.T) {
 		require.NoError(t, f.Close())
 	})
 }
+
+func TestWriteAtDoesNotMoveSeekOffset(t *testing.T) {
+	eachBasicFS(t, func(t *testing.T, fs Basic) {
+		f, err := fs.Create("foo")
+		require.NoError(t, err)
+
+		_, err = f.Write([]byte("HDR!0000"))
+		require.NoError(t, err)
+		_, err = f.Write([]byte("BODYBODYBODY"))
+		require.NoError(t, err)
+
+		_, err = f.WriteAt([]byte("0020"), 4)
+		require.NoError(t, err)
+
+		off, err := f.Seek(0, io.SeekCurrent)
+		require.NoError(t, err)
+		require.Equal(t, int64(20), off)
+
+		_, err = f.Write([]byte("<EOF>"))
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		read, err := fs.Open("foo")
+		require.NoError(t, err)
+		all, err := io.ReadAll(read)
+		require.NoError(t, err)
+		require.Equal(t, "HDR!0020BODYBODYBODY<EOF>", string(all))
+	})
+}

--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -816,6 +816,8 @@ func TestTruncate(t *testing.T) {
 
 func TestWriteAtDoesNotMoveSeekOffset(t *testing.T) {
 	eachBasicFS(t, func(t *testing.T, fs Basic) {
+		t.Helper()
+
 		f, err := fs.Create("foo")
 		require.NoError(t, err)
 
@@ -840,5 +842,6 @@ func TestWriteAtDoesNotMoveSeekOffset(t *testing.T) {
 		all, err := io.ReadAll(read)
 		require.NoError(t, err)
 		require.Equal(t, "HDR!0020BODYBODYBODY<EOF>", string(all))
+		require.NoError(t, read.Close())
 	})
 }


### PR DESCRIPTION
`memfs`'s `WriteAt` moves the handle's seek offset, so a caller that patches an earlier region in
place and keeps writing overwrites its own data — with no error.

`io.WriterAt`, which `billy.File` embeds at `fs.go:178`:

> WriteAt should not affect nor be affected by the underlying seek offset.

Same caller code through three implementations — write a placeholder header, write a body, patch the
header via `WriteAt`, then write a footer:

```
os.File      content="HDR!0020BODYBODYBODY<EOF>"   offset after WriteAt = 20
billy osfs   content="HDR!0020BODYBODYBODY<EOF>"   offset after WriteAt = 20
billy memfs  content="HDR!0020<EOF>ODYBODY"        offset after WriteAt =  8
```

Every call returned a nil error. memfs rewound to 8 and wrote the footer over the body.

`memfs/file.go:87`:

```go
n, err := f.content.WriteAt(p, off)
f.position = off + int64(n)
```

The assignment cannot simply be dropped, because `Write` (`memfs/file.go:70`) is
`return f.WriteAt(p, f.position)` and relies on that side effect to advance. So the fix moves the
advance into `Write`, where it belongs, and leaves `WriteAt` offset-free.

`osfs` (a real `os.File`) and `osfs/mmap_file.go` already honour the contract, and the `File`
interface already carries a note requiring `ReadAt` to match `io.ReaderAt` — `WriteAt` is the one
that drifted.

### Test

Added to the shared conformance suite in `test/basic_test.go`, which `eachBasicFS` runs over both
`osfs` and `memfs` (`test/common_posix.go:20`), so `osfs` supplies the expected values rather than
me asserting them. Red with only `memfs/file.go` reverted — and only the memfs subtest fails:

```
--- FAIL: TestWriteAtDoesNotMoveSeekOffset/1-*chroot.ChrootHelper
    expected: 20
    actual  : 8
```

Green with the change; `go test ./...` passes across all packages and `gofmt -l` lists neither file.

`grep WriteAt --include='*_test.go'` finds a single hit, in `osfs/mmap_file_test.go` — memfs's
`WriteAt` had no test, and nothing anywhere interleaved it with `Write`, which is the combination
that fails.

---

Disclosure: prepared with AI assistance; I verified the three-way comparison and the red/green runs
myself.
